### PR TITLE
Use ctx.Done() rather than a stop channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ run-dev:
 	    cmd/mysql-operator/main.go \
 	    --kubeconfig=${KUBECONFIG} \
 	    --v=4 \
-	    --namespace=default
+	    --namespace=${USER}
 
 .PHONY: generate
 generate:

--- a/pkg/controllers/cluster/manager/cluster_manager.go
+++ b/pkg/controllers/cluster/manager/cluster_manager.go
@@ -251,10 +251,10 @@ func (m *ClusterManager) bootstrap(ctx context.Context) (*innodb.ClusterStatus, 
 
 // Run runs the ClusterManager controller.
 // NOTE: ctx is not currently used for cancellation by caller (the stopCh is).
-func (m *ClusterManager) Run(ctx context.Context, stopCh <-chan struct{}) {
-	wait.Until(func() { m.Sync(ctx) }, time.Second*pollingIntervalSeconds, stopCh)
+func (m *ClusterManager) Run(ctx context.Context) {
+	wait.Until(func() { m.Sync(ctx) }, time.Second*pollingIntervalSeconds, ctx.Done())
 
-	<-stopCh
+	<-ctx.Done()
 
 	// Stop the primary-only controllers if they're running
 	if m.primaryCancelFunc != nil {

--- a/pkg/controllers/restore/agent_controller.go
+++ b/pkg/controllers/restore/agent_controller.go
@@ -1,6 +1,7 @@
 package restore
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -138,7 +139,7 @@ func NewAgentController(
 // Run is a blocking function that runs the specified number of worker
 // goroutines to process items in the work queue. It will return when it
 // receives on the stopCh channel.
-func (controller *AgentController) Run(numWorkers int, stopCh <-chan struct{}) error {
+func (controller *AgentController) Run(ctx context.Context, numWorkers int) error {
 	var wg sync.WaitGroup
 
 	defer func() {
@@ -160,7 +161,7 @@ func (controller *AgentController) Run(numWorkers int, stopCh <-chan struct{}) e
 	defer glog.Info("Shutting down AgentController")
 
 	glog.Info("Waiting for caches to sync")
-	if !controllerutils.WaitForCacheSync(controllerAgentName, stopCh,
+	if !controllerutils.WaitForCacheSync(controllerAgentName, ctx.Done(),
 		controller.restoreListerSynced,
 		controller.clusterListerSynced,
 		controller.backupListerSynced,
@@ -172,12 +173,12 @@ func (controller *AgentController) Run(numWorkers int, stopCh <-chan struct{}) e
 	wg.Add(numWorkers)
 	for i := 0; i < numWorkers; i++ {
 		go func() {
-			wait.Until(controller.runWorker, time.Second, stopCh)
+			wait.Until(controller.runWorker, time.Second, ctx.Done())
 			wg.Done()
 		}()
 	}
 
-	<-stopCh
+	<-ctx.Done()
 
 	return nil
 }

--- a/pkg/controllers/restore/operator_controller.go
+++ b/pkg/controllers/restore/operator_controller.go
@@ -1,6 +1,7 @@
 package restore
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -133,7 +134,7 @@ func NewOperatorController(
 // Run is a blocking function that runs the specified number of worker
 // goroutines to process items in the work queue. It will return when it
 // receives on the stopCh channel.
-func (controller *OperatorController) Run(numWorkers int, stopCh <-chan struct{}) error {
+func (controller *OperatorController) Run(ctx context.Context, numWorkers int) error {
 	var wg sync.WaitGroup
 
 	defer func() {
@@ -155,7 +156,7 @@ func (controller *OperatorController) Run(numWorkers int, stopCh <-chan struct{}
 	defer glog.Info("Shutting down OperatorController")
 
 	glog.Info("Waiting for caches to sync")
-	if !controllerutils.WaitForCacheSync(controllerAgentName, stopCh,
+	if !controllerutils.WaitForCacheSync(controllerAgentName, ctx.Done(),
 		controller.restoreListerSynced,
 		controller.clusterListerSynced,
 		controller.backupListerSynced,
@@ -167,12 +168,12 @@ func (controller *OperatorController) Run(numWorkers int, stopCh <-chan struct{}
 	wg.Add(numWorkers)
 	for i := 0; i < numWorkers; i++ {
 		go func() {
-			wait.Until(controller.runWorker, time.Second, stopCh)
+			wait.Until(controller.runWorker, time.Second, ctx.Done())
 			wg.Done()
 		}()
 	}
 
-	<-stopCh
+	<-ctx.Done()
 
 	return nil
 }

--- a/pkg/util/signals/signal.go
+++ b/pkg/util/signals/signal.go
@@ -17,27 +17,25 @@ limitations under the License.
 package signals
 
 import (
+	"context"
 	"os"
 	"os/signal"
 )
 
 var onlyOneSignalHandler = make(chan struct{})
 
-// SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
-// which is closed on one of these signals. If a second signal is caught, the program
-// is terminated with exit code 1.
-func SetupSignalHandler() (stopCh <-chan struct{}) {
+// SetupSignalHandler sets up a signal handler that calls the given CancelFunc
+// on SIGTERM/SIGINT. If a second signal is caught, the program is terminated
+// immediately with exit code 1.
+func SetupSignalHandler(cancelFunc context.CancelFunc) {
 	close(onlyOneSignalHandler) // panics when called twice
 
-	stop := make(chan struct{})
 	c := make(chan os.Signal, 2)
 	signal.Notify(c, shutdownSignals...)
 	go func() {
 		<-c
-		close(stop)
+		cancelFunc()
 		<-c
 		os.Exit(1) // second signal. Exit directly.
 	}()
-
-	return stop
 }


### PR DESCRIPTION
Adds a top level context to both the operator and the agent, wires up SIGINT/SIGTERM to call `cancelFunc`, and uses `ctx.Done()` instead of a stop chan.