### PR TITLE
E2E pipeline updates

### DIFF
--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -1,3 +1,5 @@
+// +build all default
+
 package e2e
 
 import (

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -1,3 +1,5 @@
+// +build all default
+
 package e2e
 
 import (

--- a/test/e2e/container_recovery_test.go
+++ b/test/e2e/container_recovery_test.go
@@ -1,3 +1,5 @@
+// +build all default
+
 package e2e
 
 import (

--- a/test/e2e/pod_recovery_test.go
+++ b/test/e2e/pod_recovery_test.go
@@ -1,3 +1,5 @@
+// +build all default
+
 package e2e
 
 import (

--- a/test/e2e/scheduled_backup_test.go
+++ b/test/e2e/scheduled_backup_test.go
@@ -1,3 +1,5 @@
+// +build all default
+
 package e2e
 
 import (

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -1,3 +1,5 @@
+// +build all upgrade
+
 package e2e
 
 import (

--- a/wercker.yml
+++ b/wercker.yml
@@ -78,57 +78,17 @@ push-agent-image:
       entrypoint: /mysql-agent
       user: mysql
 
-e2e-test-TestCreateCluster:
+e2e-test-default:
   base-path: "/go/src/github.com/oracle/mysql-operator"
   box:
     registry: https://wcr.io/v2
     id: wcr.io/oracle/mysql-operator-ci-e2e:1.0.0
   steps:
     - script:
-      name: e2e create cluster test
-      code: make e2e-TestCreateCluster
+      name: e2e default tests
+      code: make e2e-suite-default
 
-e2e-test-TestContainerCrashRecovery:
-  base-path: "/go/src/github.com/oracle/mysql-operator"
-  box:
-    registry: https://wcr.io/v2
-    id: wcr.io/oracle/mysql-operator-ci-e2e:1.0.0
-  steps:
-    - script:
-      name: e2e container crash recovery Test
-      code: make e2e-TestContainerCrashRecovery
-
-e2e-test-TestPodCrashRecovery:
-  base-path: "/go/src/github.com/oracle/mysql-operator"
-  box:
-    registry: https://wcr.io/v2
-    id: wcr.io/oracle/mysql-operator-ci-e2e:1.0.0
-  steps:
-    - script:
-      name: e2e pod crash recovery Test
-      code: make e2e-TestPodCrashRecovery
-
-e2e-test-TestBackUpRestore:
-  base-path: "/go/src/github.com/oracle/mysql-operator"
-  box:
-    registry: https://wcr.io/v2
-    id: wcr.io/oracle/mysql-operator-ci-e2e:1.0.0
-  steps:
-    - script:
-      name: e2e backup restore test
-      code: make e2e-TestBackUpRestore
-
-e2e-test-TestScheduledBackup:
-  base-path: "/go/src/github.com/oracle/mysql-operator"
-  box:
-    registry: https://wcr.io/v2
-    id: wcr.io/oracle/mysql-operator-ci-e2e:1.0.0
-  steps:
-    - script:
-      name: e2e scheduled backup test
-      code: make e2e-TestScheduledBackup
-
-e2e-test-TestUpgrade:
+e2e-test-upgrade:
   base-path: "/go/src/github.com/oracle/mysql-operator"
   box:
     registry: https://wcr.io/v2
@@ -137,12 +97,12 @@ e2e-test-TestUpgrade:
     - script:
       name: e2e upgrade test
       code: |
-        make e2e-teardown-TestUpgrade
+        make e2e-suite-teardown-upgrade
         if [ $(git log -1 --pretty=format:"%H" HEAD) == $(git log -1 --pretty=format:"%H" origin/master) ]; then
-            make e2e-setup-TestUpgrade MYSQL_OPERATOR_VERSION=$(git log -1 --pretty=format:"%H" origin/master~1)
+            make e2e-suite-setup-upgrade MYSQL_OPERATOR_VERSION=$(git log -1 --pretty=format:"%H" origin/master~1)
         else
-            make e2e-setup-TestUpgrade MYSQL_OPERATOR_VERSION=$(git log -1 --pretty=format:"%H" origin/master)
+            make e2e-suite-setup-upgrade MYSQL_OPERATOR_VERSION=$(git log -1 --pretty=format:"%H" origin/master)
         fi
-        make e2e-run-TestUpgrade
-        make e2e-teardown-TestUpgrade
+        E2E_NON_BUFFERED_LOGS=true make e2e-suite-run-upgrade
+        make e2e-suite-teardown-upgrade
         


### PR DESCRIPTION
Previously there was a wercker pipeline per e2e test, thus the test
parallelism was achieved thorugh wercker. However, this meant that
adding an e2e test was painful, as we had to add the test, update the
wercker yaml and configure the new pipeline in the wercker UI.

This patch aims to implement the test parallelism inside 'go test' instead.
We can then have just 2 piplines, one for running the upgrade test (as
it needs it's own operator) and the other for running all of the other
e2e tests, thus adding a new test should just be a case of adding the
test code.

Note: The upgrade pipeline runs with non-buffered logs. This is ok
as there is only a single test in this suite. Also, this prevents
the test timing out in wercker due to lack of activity on stdout.