### PR TITLE
Issue 5. MySQLOperator Global Config.

### DIFF
--- a/cmd/mysql-operator/app/mysql_operator.go
+++ b/cmd/mysql-operator/app/mysql_operator.go
@@ -85,6 +85,7 @@ func Run(s *options.MySQLOperatorServer) error {
 	var wg sync.WaitGroup
 
 	clusterController := cluster.NewController(
+		*s,
 		mysqlopClient,
 		kubeClient,
 		serverVersion,

--- a/cmd/mysql-operator/app/options/options_test.go
+++ b/cmd/mysql-operator/app/options/options_test.go
@@ -1,0 +1,74 @@
+// Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEnsureDefaults(t *testing.T) {
+	server := MySQLOperatorServer{}
+	server.EnsureDefaults()
+	assertRequiredDefaults(t, server)
+}
+
+func assertRequiredDefaults(t *testing.T, s MySQLOperatorServer) {
+	if &s == nil {
+		t.Error("MySQLOperatorServer: was nil, expected a valid configuration.")
+	}
+	if len(s.Hostname) <= 0 {
+		t.Errorf("MySQLOperatorServer: expected a non-zero length hostname, got '%s'.", s.Hostname)
+	}
+	if &s.Images == nil {
+		t.Error("MySQLOperatorServer.Images: was nil, expected a valid configuration.")
+	}
+	if s.Images.MySQLServerImage != mysqlServer {
+		t.Errorf("MySQLOperatorServer.Images.MySQLServerImage: was '%s', expected '%s'.", s.Images.MySQLServerImage, mysqlServer)
+	}
+	if s.Images.MySQLAgentImage != mysqlAgent {
+		t.Errorf("MySQLOperatorServer.Images.MySQLAgentImage: was '%s', expected '%s'.", s.Images.MySQLAgentImage, mysqlAgent)
+	}
+	expectedDuration := v1.Duration{Duration: 43200000000000}
+	if &s.MinResyncPeriod == nil {
+		t.Errorf("MySQLOperatorServer.MinResyncPeriod: was nil, expected '%s'.", expectedDuration)
+	}
+	if s.MinResyncPeriod != expectedDuration {
+		t.Errorf("MySQLOperatorServer.MinResyncPeriod: was '%s', expected '%s'.", s.MinResyncPeriod, expectedDuration)
+	}
+}
+
+func TestEnsureDefaultsOverrideSafety(t *testing.T) {
+	expected := mockMySQLOperatorServer()
+	ensured := mockMySQLOperatorServer()
+	ensured.EnsureDefaults()
+	if expected != ensured {
+		t.Errorf("MySQLOperatorServer.EnsureDefaults() should not modify pre-configured values.")
+	}
+}
+
+func mockMySQLOperatorServer() MySQLOperatorServer {
+	return MySQLOperatorServer{
+		KubeConfig: "some-kube-config",
+		Master:     "some-master",
+		Hostname:   "some-hostname",
+		Images: Images{
+			MySQLServerImage: "some-mysql-img",
+			MySQLAgentImage:  "some-agent-img",
+		},
+		MinResyncPeriod: v1.Duration{Duration: 42},
+	}
+}

--- a/cmd/mysql-operator/main.go
+++ b/cmd/mysql-operator/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
 	flags "k8s.io/apiserver/pkg/util/flag"
@@ -28,14 +29,22 @@ import (
 	"github.com/oracle/mysql-operator/pkg/version"
 )
 
-func main() {
-	fmt.Fprintf(os.Stderr, "Starting mysql-operator version %s\n", version.GetBuildVersion())
-	opts := options.NewMySQLOperatorServer()
-	opts.AddFlags(pflag.CommandLine)
+const (
+	configPath      = "/etc/mysql-operator/mysql-operator-config.yaml"
+	metricsEndpoint = "0.0.0.0:8080"
+)
 
-	flags.InitFlags()
+func main() {
+	fmt.Fprintf(os.Stderr, "Starting mysql-operator version '%s'\n", version.GetBuildVersion())
 	logs.InitLogs()
 	defer logs.FlushLogs()
+
+	opts, err := options.NewMySQLOperatorServer(configPath)
+	if err != nil {
+		glog.Fatalf("Unable to start MySQLOperator: %v.", err)
+	}
+	opts.AddFlags(pflag.CommandLine)
+	flags.InitFlags()
 
 	if err := app.Run(opts); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/docs/user/config.md
+++ b/docs/user/config.md
@@ -1,0 +1,87 @@
+# Config
+
+## Introduction
+
+Some aspects of the MySQL Operator can be configured via:
+
+1. MySQL Operator Command Line Parameters.
+2. MySQL Operator ConfigMap.
+
+When applicable, a commandline parameter will override the equivalent config 
+map parameter.
+
+Most of the time it should not be neccessary to supply any specific 
+configuration and the operator will use sensible defaults when required 
+values are not specified.
+
+
+### Create a MySQLOperator deployment with volume mounted configuration.
+
+In some cases, however, it may be desirable to configure aspects of the 
+controller. For example, during development you may wish to use a 
+different 'mysql-server' or 'mysql-agent' image.
+
+The following Helm chart snippet does just that by configuring a 
+config map and volume mounting it to the known location: 
+_/etc/mysql-operator/mysql-operator-config.yaml_
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-operator-config
+  namespace: {{.Values.operator.namespace}}
+  labels:
+    app: mysql-operator
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+data:
+  mysql-operator-config.yaml: |
+    images: 
+      mysqlServer: mysql/mysql-server
+      mysqlAgent: wcr.io/oracle/mysql-agent
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mysql-operator
+  namespace: {{.Values.operator.namespace}}
+  labels:
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql-operator
+  template:
+    metadata:
+      labels:
+        app: mysql-operator
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      serviceAccountName: mysql-operator
+      imagePullSecrets:
+        - name: {{ .Values.docker.pullSecret }}
+      volumes:
+        - name: mysql-operator-config-volume
+          configMap:
+            name: mysql-operator-config
+      containers:
+      - name: mysql-operator-controller
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: wcr.io/oracle/mysql-operator:{{ .Values.image.tag }}
+        ports:
+        - containerPort: 10254
+        volumeMounts:
+        - name: mysql-operator-config-volume
+          mountPath: /etc/mysql-operator
+        args:
+          - --v=4
+{{- if not .Values.operator.global }}
+          - --namespace={{- .Values.operator.namespace }}
+{{- end }}
+```

--- a/pkg/controllers/cluster/pod_control.go
+++ b/pkg/controllers/cluster/pod_control.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/oracle/mysql-operator/pkg/constants"
 	"github.com/oracle/mysql-operator/pkg/controllers/util"
-	statefulsets "github.com/oracle/mysql-operator/pkg/resources/statefulsets"
+	"github.com/oracle/mysql-operator/pkg/resources/statefulsets"
 )
 
 // PodControlInterface defines the interface that the
@@ -49,14 +49,15 @@ func (rpc *realPodControl) PatchPod(old *v1.Pod, new *v1.Pod) error {
 	return err
 }
 
-// updatePodToOperatorVersion sets the specified MySQLOperator version on all valid parts
-// of the Pod.
-func updatePodToOperatorVersion(pod *v1.Pod, version string) *v1.Pod {
-	newAgentImage := fmt.Sprintf("%s:%s", statefulsets.AgentImageName, version)
-
+// updatePodToOperatorVersion sets the specified MySQLOperator version on:
+//   1. The Pod operator version label.
+//   2. The MySQLAgent container image version
+func updatePodToOperatorVersion(pod *v1.Pod, mysqlAgentImage, version string) *v1.Pod {
+	targetContainer := statefulsets.MySQLAgentName
+	newAgentImage := fmt.Sprintf("%s:%s", mysqlAgentImage, version)
 	pod.Labels[constants.MySQLOperatorVersionLabel] = version
 	for idx, container := range pod.Spec.Containers {
-		if container.Name == statefulsets.MySQLAgentContainerName {
+		if container.Name == targetContainer {
 			pod.Spec.Containers[idx].Image = newAgentImage
 			break
 		}

--- a/pkg/controllers/cluster/statefulset_control.go
+++ b/pkg/controllers/cluster/statefulset_control.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/oracle/mysql-operator/pkg/constants"
 	"github.com/oracle/mysql-operator/pkg/controllers/util"
-	statefulsets "github.com/oracle/mysql-operator/pkg/resources/statefulsets"
+	"github.com/oracle/mysql-operator/pkg/resources/statefulsets"
 )
 
 // StatefulSetControlInterface defines the interface that the
@@ -68,18 +68,18 @@ func (rssc *realStatefulSetControl) PatchStatefulSet(old *apps.StatefulSet, new 
 	return err
 }
 
-// updateStatefulSetToOperatorVersion sets the specified MySQLOperator version on all valid parts
-// of the StatefulSet.
-func updateStatefulSetToOperatorVersion(ss *apps.StatefulSet, version string) *apps.StatefulSet {
-	newAgentImage := fmt.Sprintf("%s:%s", statefulsets.AgentImageName, version)
-
+// updateStatefulSetToOperatorVersion sets the specified MySQLOperator version on:
+//   1. The StatefulSet operator version label.
+//   2. The MySQLAgent container image version
+func updateStatefulSetToOperatorVersion(ss *apps.StatefulSet, mysqlAgentImage string, version string) *apps.StatefulSet {
+	targetContainer := statefulsets.MySQLAgentName
+	newAgentImage := fmt.Sprintf("%s:%s", mysqlAgentImage, version)
 	ss.ObjectMeta.Labels[constants.MySQLOperatorVersionLabel] = version
 	for idx, container := range ss.Spec.Template.Spec.Containers {
-		if container.Name == statefulsets.MySQLAgentContainerName {
+		if container.Name == targetContainer {
 			ss.Spec.Template.Spec.Containers[idx].Image = newAgentImage
 			break
 		}
 	}
-
 	return ss
 }

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -21,8 +21,15 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	options "github.com/oracle/mysql-operator/cmd/mysql-operator/app/options"
 	api "github.com/oracle/mysql-operator/pkg/apis/mysql/v1"
 )
+
+func mockOperatorConfig() options.MySQLOperatorServer {
+	opts := options.MySQLOperatorServer{}
+	opts.EnsureDefaults()
+	return opts
+}
 
 func TestMySQLRootPasswordNoSecretRef(t *testing.T) {
 	cluster := &api.MySQLCluster{
@@ -58,7 +65,7 @@ func TestClusterWithoutPVCHasBackupContainerAndVolumes(t *testing.T) {
 		},
 	}
 
-	statefulSet := NewForCluster(cluster, "mycluster")
+	statefulSet := NewForCluster(cluster, mockOperatorConfig().Images, "mycluster")
 	containers := statefulSet.Spec.Template.Spec.Containers
 	volumes := statefulSet.Spec.Template.Spec.Volumes
 	if len(volumes) != 2 {
@@ -79,7 +86,7 @@ func TestClusterWithPVCHasBackupContainerAndVolumes(t *testing.T) {
 		},
 	}
 
-	statefulSet := NewForCluster(cluster, "mycluster")
+	statefulSet := NewForCluster(cluster, mockOperatorConfig().Images, "mycluster")
 	containers := statefulSet.Spec.Template.Spec.Containers
 	volumes := statefulSet.Spec.Template.Spec.Volumes
 	if len(volumes) != 0 {
@@ -99,7 +106,7 @@ func TestClusterHasNodeSelector(t *testing.T) {
 		},
 	}
 
-	statefulSet := NewForCluster(cluster, "mycluster")
+	statefulSet := NewForCluster(cluster, mockOperatorConfig().Images, "mycluster")
 
 	if !reflect.DeepEqual(statefulSet.Spec.Template.Spec.NodeSelector, nvmeSelector) {
 		t.Errorf("Expected cluster with NVMe node selector")
@@ -115,7 +122,7 @@ func TestClusterCustomConfig(t *testing.T) {
 		},
 	}
 
-	statefulSet := NewForCluster(cluster, "mycluster")
+	statefulSet := NewForCluster(cluster, mockOperatorConfig().Images, "mycluster")
 	containers := statefulSet.Spec.Template.Spec.Containers
 
 	var hasExpectedVolumeMount = false

--- a/test/e2e/scripts/e2e-mysql-operator-cluster.sh
+++ b/test/e2e/scripts/e2e-mysql-operator-cluster.sh
@@ -270,7 +270,6 @@ function teardown() {
     delete_mysql_operator_namespace
 }
 
-
 # ------------------------------------------------------------------------------
 USE_RBAC=${USE_RBAC:-true}
 


### PR DESCRIPTION
First implementation, based on discussion with @owainlewis and issue info: https://github.com/oracle/mysql-operator/issues/5

Uses a volume based secret (as suggested by OL). Other options are available (literals, environment variables), and operator controller also (already) has access to ConfigMaps via an informer if we want to change in the future.


