### PR TITLE
Update the project in preparation for open source. Publish 0.1.0 release

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -16,31 +16,11 @@ First create the namespace that the operator will reside in:
 kubectl create ns mysql-operator
 ```
 
-Next, export a docker secret which holds the ODX Docker Registry password. Our images are published to a shared
-private Docker registry. Until there are public repos available, you will need a secret to pull images from this repository.
-
-You will need to create a secret in **both** the default and mysql-operator namespace.
-
-```
-kubectl -n mysql-operator create secret docker-registry odx-docker-pull-secret \
---docker-server="wcr.io" \
---docker-username="XXX" \
---docker-password="XXX" \
---docker-email="k8s@oracle.com"
-
-kubectl create secret docker-registry odx-docker-pull-secret \
---docker-server="wcr.io" \
---docker-username="XXX" \
---docker-password="XXX" \
---docker-email="k8s@oracle.com"
-```
-
 ## Deploy a version of the MySQL Operator using Helm
 
 The MySQL Operator is installed into your cluster via a Helm chart
 
 ### Ensure you have Helm installed and working.
-
 
 Install the helm tool locally by following [these instructions](https://docs.helm.sh/using_helm/#installing-helm)
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# This script will pull down an existing build and tag it for release.
+# Example: SHA=492978... RELEASE=0.1.0 hack/release.sh
+
+set -e
+
+RELEASE=${RELEASE:=0.1.0}
+
+SHA=${SHA:=$(git rev-parse HEAD)}
+
+OPERATOR_IMAGE=wcr.io/oracle/mysql-operator
+AGENT_IMAGE=wcr.io/oracle/mysql-agent
+
+function do_release() {
+    echo "Creating release $RELEASE from existing version $SHA"
+
+    if git rev-parse "$RELEASE" >/dev/null 2>&1; then
+        echo "Tag $RELEASE already exists. Doing nothing."
+        exit 1
+    fi
+
+    echo "Creating images"
+    docker pull $OPERATOR_IMAGE:$SHA
+    docker tag $OPERATOR_IMAGE:$SHA $OPERATOR_IMAGE:$RELEASE
+    docker push $OPERATOR_IMAGE:$RELEASE
+
+    docker pull $AGENT_IMAGE:$SHA
+    docker tag $AGENT_IMAGE:$SHA $AGENT_IMAGE:$RELEASE
+    docker push $AGENT_IMAGE:$RELEASE
+
+    echo "Creating release tag $RELEASE"
+    git tag -a "$RELEASE" -m "Release version: $RELEASE"
+    git push --tags
+}
+
+read -r -p "Are you sure you want to release ${SHA} as ${RELEASE}? [y/N] " response
+case "$response" in
+    [yY][eE][sS]|[yY])
+        do_release
+        ;;
+    *)
+        exit
+        ;;
+esac

--- a/mysql-operator/Chart.yaml
+++ b/mysql-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mysql-operator
 version: 0.1.0
-description: A Helm chart for deploying the Oracle mysql-operator
+description: A Helm chart for deploying the Oracle MySQL Operator
 maintainers:
   - name: Owain Lewis
     email: owain.lewis@oracle.com

--- a/mysql-operator/templates/03-deployment.yaml
+++ b/mysql-operator/templates/03-deployment.yaml
@@ -21,8 +21,6 @@ spec:
         prometheus.io/port: "8080"
     spec:
       serviceAccountName: mysql-operator
-      imagePullSecrets:
-        - name: {{ .Values.docker.pullSecret }}
       containers:
       - name: mysql-operator-controller
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/mysql-operator/values.yaml
+++ b/mysql-operator/values.yaml
@@ -5,7 +5,5 @@ operator:
   global: true
   register_crd: true
 image:
-  tag: 0.3.0
+  tag: 0.1.0
   pullPolicy: Always
-docker:
-  pullSecret: odx-docker-pull-secret

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -361,12 +361,10 @@ func NewForCluster(cluster *api.MySQLCluster, images operatoropts.Images, servic
 					// create service accounts and (cluster role bindings?)
 					// for each namespace.
 					ServiceAccountName: "mysql-agent",
-					// TODO: Remove before open sourcing?
-					ImagePullSecrets: []v1.LocalObjectReference{{Name: "odx-docker-pull-secret"}},
-					NodeSelector:     cluster.Spec.NodeSelector,
-					Affinity:         cluster.Spec.Affinity,
-					Containers:       containers,
-					Volumes:          podVolumes,
+					NodeSelector:       cluster.Spec.NodeSelector,
+					Affinity:           cluster.Spec.Affinity,
+					Containers:         containers,
+					Volumes:            podVolumes,
 				},
 			},
 			ServiceName: serviceName,


### PR DESCRIPTION
In preparation for open source release we have

1. Made the mysql-operator and mysql-agent wcr.io repositories public
2. Published a 0.1.0 release of the latest tested version of the operator
3. Removed any references to the Docker pull secret from the code