### PR TITLE
 Fix logging before flag.Parse

### DIFF
--- a/cmd/mysql-agent/main.go
+++ b/cmd/mysql-agent/main.go
@@ -15,12 +15,14 @@
 package main
 
 import (
+	goflag "flag"
 	"fmt"
 	"os"
 
-	flags "k8s.io/apiserver/pkg/util/flag"
+	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 
+	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
 	"github.com/oracle/mysql-operator/cmd/mysql-agent/app"
@@ -30,12 +32,21 @@ import (
 
 func main() {
 	fmt.Fprintf(os.Stderr, "Starting mysql-agent version %s\n", version.GetBuildVersion())
-	opts := options.NewMySQLAgentOpts()
-	opts.AddFlags(pflag.CommandLine)
 
-	flags.InitFlags()
+	opts := options.NewMySQLAgentOpts()
+
+	opts.AddFlags(pflag.CommandLine)
+	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	pflag.Parse()
+	goflag.CommandLine.Parse([]string{})
+
 	logs.InitLogs()
 	defer logs.FlushLogs()
+
+	pflag.VisitAll(func(flag *pflag.Flag) {
+		glog.V(2).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
 
 	if err := app.Run(opts); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/cmd/mysql-operator/app/options/options.go
+++ b/cmd/mysql-operator/app/options/options.go
@@ -87,7 +87,6 @@ func NewMySQLOperatorServer(filePath string) (*MySQLOperatorServer, error) {
 			return nil, errors.Wrapf(err, "failed to parse MySQLOperator configuration: '%s'", filePath)
 		}
 	} else {
-		glog.Infof("No '%s' was present.", filePath)
 		config = MySQLOperatorServer{}
 	}
 	config.EnsureDefaults()


### PR DESCRIPTION
See: https://github.com/kubernetes/kubernetes/issues/17162

Before:

```
❯ MYSQL_AGENT_VERSION=0.1.0 make run-dev
Starting mysql-operator version '0.1.0'
ERROR: logging before flag.Parse: I0412 18:36:01.396104   27519 options.go:90] No '/etc/mysql-operator/mysql-operator-config.yaml' was present.
ERROR: logging before flag.Parse: I0412 18:36:01.397000   27519 flags.go:52] FLAG: --alsologtostderr="false"
ERROR: logging before flag.Parse: I0412 18:36:01.397020   27519 flags.go:52] FLAG: --kubeconfig="/Users/apryde/.kube/config"
ERROR: logging before flag.Parse: I0412 18:36:01.397032   27519 flags.go:52] FLAG: --log-backtrace-at=":0"
ERROR: logging before flag.Parse: I0412 18:36:01.397045   27519 flags.go:52] FLAG: --log-dir=""
ERROR: logging before flag.Parse: I0412 18:36:01.397056   27519 flags.go:52] FLAG: --log-flush-frequency="5s"
ERROR: logging before flag.Parse: I0412 18:36:01.397069   27519 flags.go:52] FLAG: --logtostderr="true"
ERROR: logging before flag.Parse: I0412 18:36:01.397080   27519 flags.go:52] FLAG: --master=""
ERROR: logging before flag.Parse: I0412 18:36:01.397090   27519 flags.go:52] FLAG: --min-resync-period="12h0m0s"
ERROR: logging before flag.Parse: I0412 18:36:01.397100   27519 flags.go:52] FLAG: --mysql-agent-image="wcr.io/oracle/mysql-agent"
ERROR: logging before flag.Parse: I0412 18:36:01.401385   27519 flags.go:52] FLAG: --mysql-server-image="mysql/mysql-server"
ERROR: logging before flag.Parse: I0412 18:36:01.401474   27519 flags.go:52] FLAG: --namespace="apryde"
ERROR: logging before flag.Parse: I0412 18:36:01.401558   27519 flags.go:52] FLAG: --stderrthreshold="2"
ERROR: logging before flag.Parse: I0412 18:36:01.401604   27519 flags.go:52] FLAG: --v="4"
ERROR: logging before flag.Parse: I0412 18:36:01.401616   27519 flags.go:52] FLAG: --vmodule=""
```

After:
```
❯ MYSQL_AGENT_VERSION=0.1.0 make run-dev
Starting mysql-operator version '0.1.0'
I0412 18:53:07.419607   31986 main.go:57] FLAG: --alsologtostderr="false"
I0412 18:53:07.419685   31986 main.go:57] FLAG: --kubeconfig="/Users/apryde/.kube/config"
I0412 18:53:07.419691   31986 main.go:57] FLAG: --log-backtrace-at=":0"
I0412 18:53:07.419698   31986 main.go:57] FLAG: --log-dir=""
I0412 18:53:07.419703   31986 main.go:57] FLAG: --log-flush-frequency="5s"
I0412 18:53:07.419709   31986 main.go:57] FLAG: --logtostderr="true"
I0412 18:53:07.419714   31986 main.go:57] FLAG: --master=""
I0412 18:53:07.419718   31986 main.go:57] FLAG: --min-resync-period="12h0m0s"
I0412 18:53:07.419723   31986 main.go:57] FLAG: --mysql-agent-image="wcr.io/oracle/mysql-agent"
I0412 18:53:07.419728   31986 main.go:57] FLAG: --mysql-server-image="mysql/mysql-server"
I0412 18:53:07.419732   31986 main.go:57] FLAG: --namespace="apryde"
I0412 18:53:07.419737   31986 main.go:57] FLAG: --stderrthreshold="2"
I0412 18:53:07.419741   31986 main.go:57] FLAG: --v="4"
I0412 18:53:07.419745   31986 main.go:57] FLAG: --vmodule=""
```