### PR TITLE
Update example manifests to use OCI block volumes

### DIFF
--- a/examples/cluster/cluster-with-volume.yaml
+++ b/examples/cluster/cluster-with-volume.yaml
@@ -1,35 +1,20 @@
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  labels:
-    type: local
-  name: mysql-cluster-with-volume
-spec:
-  accessModes:
-  - ReadWriteMany
-  capacity:
-    storage: 10Gi
-  hostPath:
-    path: /tmp/data
-  persistentVolumeReclaimPolicy: Recycle
-  storageClassName: manual
----
+# This example will create a MySQL cluster which persists data to an OCI Block Volume.
 apiVersion: "mysql.oracle.com/v1"
 kind: MySQLCluster
 metadata:
   name: mysql
 spec:
-  replicas: 1
-  secretRef:
-    name: mysql-root-user-secret
+  replicas: 3
   volumeClaimTemplate:
     metadata:
-      name: data
+      name: mysql-block-volume
     spec:
-      storageClassName: manual
+      storageClassName: "oci"
+      selector:
+        matchLabels:
+          oci-availability-domain: "PHX-AD-1"
       accessModes:
-        - ReadWriteMany
+        - ReadWriteOnce
       resources:
         requests:
-          storage: 1Gi
+          storage: 50Gi

--- a/examples/demo/wordpress/wordpress-database.yaml
+++ b/examples/demo/wordpress/wordpress-database.yaml
@@ -1,19 +1,12 @@
 ---
+kind: ConfigMap
 apiVersion: v1
-kind: PersistentVolume
 metadata:
-  labels:
-    type: local
-  name: mysql-local-volume
-spec:
-  accessModes:
-  - ReadWriteMany
-  capacity:
-    storage: 1Gi
-  hostPath:
-    path: /tmp
-  persistentVolumeReclaimPolicy: Recycle
-  storageClassName: manual
+  name: wordpress-mysql-config
+data:
+  my.cnf: |-
+    [mysqld]
+    default_authentication_plugin=mysql_native_password
 ---
 apiVersion: "mysql.oracle.com/v1"
 kind: MySQLCluster
@@ -21,15 +14,20 @@ metadata:
   name: mysql-wordpress
 spec:
   replicas: 1
+  configRef:
+    name: wordpress-mysql-config
   secretRef:
     name: wordpress-mysql-root-password
   volumeClaimTemplate:
     metadata:
-      name: data
+      name: mysql-block-volume
     spec:
-      storageClassName: manual
+      storageClassName: "oci"
+      selector:
+        matchLabels:
+          oci-availability-domain: "PHX-AD-1"
       accessModes:
-        - ReadWriteMany
+        - ReadWriteOnce
       resources:
         requests:
-          storage: 1Gi
+          storage: 50Gi


### PR DESCRIPTION
Fixes #93. This change fixes some of the example manifests.

1. Fix the MySQL Demo 
2. Fix the volume example to use an OCI block volume