### PR TITLE
WIP simplify deployment with single manifest

### DIFF
--- a/examples/mysql-operator.yaml
+++ b/examples/mysql-operator.yaml
@@ -74,21 +74,68 @@ metadata:
   name: mysql-operator
   namespace: mysql-operator
 rules:
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
+  - apiGroups:
+    - mysql.oracle.com
+    resources:
+    - mysqlclusters
+    - mysqlbackups
+    - mysqlbackupschedules
+    - mysqlrestores
     verbs: ["*"]
-  - apiGroups: ["mysql.oracle.com"]
-    resources: ["mysqlclusters", "mysqlbackups", "mysqlrestores", "mysqlbackupschedules"]
-    verbs: ["*"]
-  - apiGroups: ["apps"]
-    resources: ["statefulsets"]
-    verbs: ["*"]
-  - apiGroups: [""]
-    resources: ["events", "services", "pods"]
-    verbs: ["*"]
-  - apiGroups: [""]
-    resources: ["secrets", "configmaps"]
-    verbs: ["watch", "create", "delete", "list"]
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+    - create
+    - delete
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - get
+    - list
+    - watch
+    - patch
+    - create
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - update
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -141,7 +188,7 @@ spec:
       serviceAccountName: mysql-operator
       containers:
       - name: mysql-operator-controller
-        image: wcr.io/oracle/mysql-operator:0.1.0
+        image: iad.ocir.io/oracle/mysql-operator:0.1.0
         env:
         - name: MYSQL_AGENT_VERSION
           value: 0.1.0

--- a/mysql-operator/mysql-operator.yaml
+++ b/mysql-operator/mysql-operator.yaml
@@ -84,12 +84,11 @@ rules:
     resources: ["statefulsets"]
     verbs: ["*"]
   - apiGroups: [""]
-    resources: ["events", "pods", "persistentvolumes", "persistentvolumeclaims", "services"]
+    resources: ["events", "services", "pods"]
     verbs: ["*"]
-  # These permissions need to be restricted since they essentially grant access to cluster level secrets
   - apiGroups: [""]
     resources: ["secrets", "configmaps"]
-    verbs: ["create", "delete"]
+    verbs: ["watch", "create", "delete", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/mysql-operator/mysql-operator.yaml
+++ b/mysql-operator/mysql-operator.yaml
@@ -1,4 +1,9 @@
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mysql-operator
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -50,10 +55,65 @@ spec:
     kind: MySQLBackupSchedule
     singular: mysqlbackupschedule
     plural: mysqlbackupschedules
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator
+  namespace: mysql-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-agent
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: mysql-operator
+  namespace: mysql-operator
+rules:
+  - apiGroups:
+    - "*"
+    resources:
+    - "*"
+    verbs:
+    - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: mysql-operator
+  namespace: mysql-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind:  ClusterRole
+  name: mysql-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: mysql-operator
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: mysql-agent
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mysql-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-agent
+  namespace: default
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: mysql-operator
+  namespace: mysql-operator
   labels:
     app: mysql-operator
 spec:
@@ -72,12 +132,8 @@ spec:
       serviceAccountName: mysql-operator
       containers:
       - name: mysql-operator-controller
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        image: wcr.io/oracle/mysql-operator:{{ .Values.image.tag }}
+        image: wcr.io/oracle/mysql-operator:0.1.0
         ports:
         - containerPort: 10254
         args:
           - --v=4
-{{- if not .Values.operator.global }}
-          - --namespace={{- .Values.operator.namespace }}
-{{- end }}    

--- a/mysql-operator/mysql-operator.yaml
+++ b/mysql-operator/mysql-operator.yaml
@@ -84,8 +84,12 @@ rules:
     resources: ["statefulsets"]
     verbs: ["*"]
   - apiGroups: [""]
-    resources: ["events", "pods", "persistentvolumes", "persistentvolumeclaims", "services", "secrets", "configmaps"]
+    resources: ["events", "pods", "persistentvolumes", "persistentvolumeclaims", "services"]
     verbs: ["*"]
+  # These permissions need to be restricted since they essentially grant access to cluster level secrets
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/mysql-operator/mysql-operator.yaml
+++ b/mysql-operator/mysql-operator.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqlclusters.mysql.oracle.com
+spec:
+  group: mysql.oracle.com
+  version: v1
+  scope: Namespaced
+  names:
+    kind: MySQLCluster
+    singular: mysqlcluster
+    plural: mysqlclusters
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqlbackups.mysql.oracle.com
+spec:
+  group: mysql.oracle.com
+  version: v1
+  scope: Namespaced
+  names:
+    kind: MySQLBackup
+    singular: mysqlbackup
+    plural: mysqlbackups
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqlrestores.mysql.oracle.com
+spec:
+  group: mysql.oracle.com
+  version: v1
+  scope: Namespaced
+  names:
+    kind: MySQLRestore
+    singular: mysqlrestore
+    plural: mysqlrestores
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqlbackupschedules.mysql.oracle.com
+spec:
+  group: mysql.oracle.com
+  version: v1
+  scope: Namespaced
+  names:
+    kind: MySQLBackupSchedule
+    singular: mysqlbackupschedule
+    plural: mysqlbackupschedules
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mysql-operator
+  labels:
+    app: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql-operator
+  template:
+    metadata:
+      labels:
+        app: mysql-operator
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+      - name: mysql-operator-controller
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: wcr.io/oracle/mysql-operator:{{ .Values.image.tag }}
+        ports:
+        - containerPort: 10254
+        args:
+          - --v=4
+{{- if not .Values.operator.global }}
+          - --namespace={{- .Values.operator.namespace }}
+{{- end }}    

--- a/mysql-operator/mysql-operator.yaml
+++ b/mysql-operator/mysql-operator.yaml
@@ -74,12 +74,18 @@ metadata:
   name: mysql-operator
   namespace: mysql-operator
 rules:
-  - apiGroups:
-    - "*"
-    resources:
-    - "*"
-    verbs:
-    - "*"
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["*"]
+  - apiGroups: ["mysql.oracle.com"]
+    resources: ["mysqlclusters", "mysqlbackups", "mysqlrestores", "mysqlbackupschedules"]
+    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["events", "pods", "persistentvolumes", "persistentvolumeclaims", "services", "secrets", "configmaps"]
+    verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -133,6 +139,9 @@ spec:
       containers:
       - name: mysql-operator-controller
         image: wcr.io/oracle/mysql-operator:0.1.0
+        env:
+        - name: MYSQL_AGENT_VERSION
+          value: 0.1.0
         ports:
         - containerPort: 10254
         args:


### PR DESCRIPTION
This change implements a simplified manifest for deploying the operator.

* Use a single file to deploy the operator
* Tighten up RBAC permissions