### PR TITLE
Fix RBAC by making more restrictive

### DIFF
--- a/mysql-operator/templates/02-rbac.yaml
+++ b/mysql-operator/templates/02-rbac.yaml
@@ -19,11 +19,67 @@ metadata:
   namespace: {{ .Values.operator.namespace}}{{ end }}
 rules:
   - apiGroups:
-    - "*"
+    - mysql.oracle.com
     resources:
-    - "*"
+    - mysqlclusters
+    - mysqlbackups
+    - mysqlbackupschedules
+    - mysqlrestores
+    verbs: ["*"]
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
     verbs:
-    - "*"
+    - get
+    - create
+    - delete
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - get
+    - list
+    - watch
+    - patch
+    - create
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - update
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: {{ if .Values.operator.global }}Cluster{{ end }}RoleBinding


### PR DESCRIPTION
This change locks down RBAC rules for the mysql-operator service account. In future we might want a separate service account for the operator and agent.