### PR TITLE
Group replication SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ dist/
 bin/
 .push-wcr*
 .container-wcr*
+.push-iad*
+.container-iad*
 
 test/system/runner.log
 test/system/terraform/cluster/.terraform/

--- a/examples/cluster/cluster-with-custom-ssl-certs.yaml
+++ b/examples/cluster/cluster-with-custom-ssl-certs.yaml
@@ -1,0 +1,8 @@
+apiVersion: "mysql.oracle.com/v1"
+kind: MySQLCluster
+metadata:
+  name: mysql
+spec:
+  replicas: 3
+  sslSecretRef:
+    name: mysql-ssl-secret

--- a/examples/custom-ssl-secret.yaml
+++ b/examples/custom-ssl-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-ssl-secret
+type: Opaque
+data:
+  ca.crt: <base64'd Root CA certificate>
+  tls.crt: <base64'd server certificate>
+  tls.key:  <base64'd server private key>

--- a/pkg/apis/mysql/v1/cluster.go
+++ b/pkg/apis/mysql/v1/cluster.go
@@ -95,6 +95,11 @@ type MySQLClusterSpec struct {
 	// ConfigRef allows a user to specify a custom configuration file for MySQL.
 	// +optional
 	ConfigRef *corev1.LocalObjectReference `json:"configRef,omitempty"`
+
+	// SSLSecretRef allows a user to specify custom CA certificate, server certificate
+	// and server key for group replication SSL
+	// +optional
+	SSLSecretRef *corev1.LocalObjectReference `json:"sslSecretRef,omitempty"`
 }
 
 // MySQLClusterPhase describes the state of the cluster.
@@ -201,6 +206,13 @@ func (c *MySQLCluster) RequiresConfigMount() bool {
 // for a MySQL cluster else false
 func (c *MySQLCluster) RequiresSecret() bool {
 	return c.Spec.SecretRef == nil
+}
+
+// RequiresCustomSSLSetup returns true is the user has provided a secret
+// that contains CA cert, server cert and server key for group replication
+// SSL support
+func (c *MySQLCluster) RequiresCustomSSLSetup() bool {
+	return c.Spec.SSLSecretRef != nil
 }
 
 // GetObjectKind is required for codegen

--- a/pkg/apis/mysql/v1/cluster_test.go
+++ b/pkg/apis/mysql/v1/cluster_test.go
@@ -17,6 +17,7 @@ package v1
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -83,4 +84,21 @@ func TestRequiresConfigMount(t *testing.T) {
 	if !cluster.RequiresConfigMount() {
 		t.Errorf("Cluster with configRef should require a config mount")
 	}
+}
+
+func TestRequiresCustomSSLSetup(t *testing.T) {
+	cluster := &MySQLCluster{}
+	cluster.EnsureDefaults()
+
+	assert.False(t, cluster.RequiresCustomSSLSetup(), "Cluster without SSLSecretRef should not require custom SSL setup")
+
+	cluster = &MySQLCluster{
+		Spec: MySQLClusterSpec{
+			SSLSecretRef: &corev1.LocalObjectReference{
+				Name: "custom-ssl-secret",
+			},
+		},
+	}
+
+	assert.True(t, cluster.RequiresCustomSSLSetup(), "Cluster with SSLSecretRef should require custom SSL setup")
 }

--- a/pkg/controllers/cluster/manager/cluster_manager.go
+++ b/pkg/controllers/cluster/manager/cluster_manager.go
@@ -258,7 +258,7 @@ func (m *ClusterManager) handleInstanceMissing(ctx context.Context, primaryAddr 
 		glog.V(4).Infof("Attempting to rejoin instance to cluster")
 		if err := primarySh.RejoinInstanceToCluster(ctx, m.Instance.GetShellURI(), mysqlsh.Options{
 			"ipWhitelist":   whitelistCIDR,
-			"memberSslMode": "DISABLED",
+			"memberSslMode": "REQUIRED",
 		}); err != nil {
 			glog.Errorf("Failed to rejoin cluster: %v", err)
 			return false
@@ -288,7 +288,7 @@ func (m *ClusterManager) handleInstanceNotFound(ctx context.Context, primaryAddr
 	}
 
 	if err := psh.AddInstanceToCluster(ctx, m.Instance.GetShellURI(), mysqlsh.Options{
-		"memberSslMode": "DISABLED",
+		"memberSslMode": "REQUIRED",
 		"ipWhitelist":   whitelistCIDR,
 	}); err != nil {
 		glog.Errorf("Failed to add to cluster: %v", err)
@@ -324,7 +324,7 @@ func (m *ClusterManager) bootstrap(ctx context.Context) (*innodb.ClusterStatus, 
 				return nil, errors.Wrap(err, "getting CIDR to whitelist for  GR")
 			}
 			opts := mysqlsh.Options{
-				"memberSslMode": "DISABLED",
+				"memberSslMode": "REQUIRED",
 				"ipWhitelist":   whitelistCIDR,
 			}
 			if m.Instance.MultiMaster {


### PR DESCRIPTION
- SSL with autogenerated certs as standard (a feature of mysql, certs valid for 10 years)
- Confirgurable with your own CA cert, tls cert and tls key via a tls secret

Limitations:
- Currently not verifying server cert against ca cert (VERIFY_CA mode).
- Only supports 1 server cert/key pair that will be mounted to all mysql containers
  - Really you'd want a new cert/key pair per pod and then turn on VERIFY_IDENTITY
      to enforce hostname/common name checking. This would require vault/cert-manager

Resolves: #89

Changelog:

```
Group communication connections as are now secured using SSL with support for specifying your own certificate [#115].
```