### PR TITLE
Independent mysql-agent ClusterRole and RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The MySQL Operator provides the following core features:
 
 ## Requirements
 
- * Kubernetes 1.7.0 +
+ * Kubernetes 1.8.0 +
 
 ## Contributing
 

--- a/cmd/mysql-operator/app/mysql_operator.go
+++ b/cmd/mysql-operator/app/mysql_operator.go
@@ -73,11 +73,6 @@ func Run(s *options.MySQLOperatorServer) error {
 	kubeClient := kubernetes.NewForConfigOrDie(kubeconfig)
 	mysqlopClient := mysqlop.NewForConfigOrDie(kubeconfig)
 
-	serverVersion, err := kubeClient.Discovery().ServerVersion()
-	if err != nil {
-		glog.Fatalf("Failed to discover Kubernetes API server version: %v", err)
-	}
-
 	// Shared informers (non namespace specific).
 	operatorInformerFactory := informers.NewFilteredSharedInformerFactory(mysqlopClient, resyncPeriod(s)(), s.Namespace, nil)
 	kubeInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod(s)(), s.Namespace, nil)
@@ -88,12 +83,10 @@ func Run(s *options.MySQLOperatorServer) error {
 		*s,
 		mysqlopClient,
 		kubeClient,
-		serverVersion,
 		operatorInformerFactory.Mysql().V1().MySQLClusters(),
 		kubeInformerFactory.Apps().V1beta1().StatefulSets(),
 		kubeInformerFactory.Core().V1().Pods(),
 		kubeInformerFactory.Core().V1().Services(),
-		kubeInformerFactory.Core().V1().ConfigMaps(),
 		30*time.Second,
 		s.Namespace,
 	)

--- a/contrib/manifests/rbac.yaml
+++ b/contrib/manifests/rbac.yaml
@@ -3,45 +3,141 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mysql-operator
+
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mysql-agent
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: Role
 metadata:
   name: mysql-operator
 rules:
   - apiGroups:
-    - "*"
+    - ""
     resources:
-    - "*"
+    - pods
     verbs:
-    - "*"
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - create
+
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+  - apiGroups:
+    - mysql.oracle.com
+    resources:
+    - mysqlbackups
+    - mysqlbackupschedules
+    - mysqlclusters
+    - mysqlrestores
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+  - apiGroups:
+    - mysql.oracle.com
+    resources:
+    - mysqlbackups
+    verbs:
+    - create
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: ClusterRole
+metadata:
+  name: mysql-agent
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+
+  - apiGroups:
+    - mysql.oracle.com
+    resources:
+    - mysqlbackups
+    - mysqlbackupschedules
+    - mysqlclusters
+    - mysqlrestores
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
 metadata:
   name: mysql-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind:  ClusterRole
+  kind:  Role
   name: mysql-operator
 subjects:
 - kind: ServiceAccount
   name: mysql-operator
   namespace: <NAMESPACE>
+
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: mysql-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: mysql-operator
+  kind: Role
+  name: mysql-agent
 subjects:
 - kind: ServiceAccount
   name: mysql-agent

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -47,10 +47,10 @@ To install the chart in a cluster without RBAC with the release name `my-release
 $ helm install --name my-release mysql-operator
 ```
 
-If your cluster has RBAC enabled then you will need to run:
+If your cluster has RBAC disabled then you will need to run:
 
 ```console
-$ helm install --name my-release mysql-operator --set rbac.enabled=true
+$ helm install --name my-release mysql-operator --set rbac.enabled=false
 ```
 
 The above command deploys the MySQL Operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -73,10 +73,37 @@ The following tables lists the configurable parameters of the MySQL-operator cha
 
 Parameter | Description | Default
 --------- | ----------- | -------
-`rbac.enabled` | If true, enables RBAC | `false`
+`rbac.enabled` | If true, enables RBAC | `true`
 `operator.namespace` | Controls the namespace in which the operator is deployed | `mysql-operator`
 
 ## Create a simple MySQL cluster
+
+The first time you create a MySQL Cluster in a namespace you need to create the
+`mysql-agent` ServiceAccount and RoleBinding in that namespace:
+
+```bash
+$ cat <<EOF | kubectl create -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-agent
+  namespace: my-namespace
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: mysql-agent
+  namespace: my-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mysql-agent
+subjects:
+- kind: ServiceAccount
+  name: mysql-agent
+  namespace: my-namespace
+EOF
+```
 
 Now let's create a new MySQL cluster. Create a cluster.yaml file with the following contents
 

--- a/mysql-operator/templates/02-rbac.yaml
+++ b/mysql-operator/templates/02-rbac.yaml
@@ -4,12 +4,14 @@ kind: ServiceAccount
 metadata:
   name: mysql-operator
   namespace: {{ if .Values.operator.global }}mysql-operator{{ else }}{{ .Values.operator.namespace}}{{ end }}
+
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mysql-agent
   namespace: {{ if .Values.operator.global }}default{{ else }}{{ .Values.operator.namespace}}{{ end }}
+
 ---
 {{- if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -19,14 +21,108 @@ metadata:
   namespace: {{ .Values.operator.namespace}}{{ end }}
 rules:
   - apiGroups:
-    - "*"
+    - ""
     resources:
-    - "*"
+    - pods
     verbs:
-    - "*"
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - create
+
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+  - apiGroups:
+    - mysql.oracle.com
+    resources:
+    - mysqlbackups
+    - mysqlbackupschedules
+    - mysqlclusters
+    - mysqlrestores
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+  - apiGroups:
+    - mysql.oracle.com
+    resources:
+    - mysqlbackups
+    verbs:
+    - create
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: {{ if .Values.operator.global }}Cluster{{ end }}RoleBinding
+kind: {{ if .Values.operator.global }}Cluster{{ end }}Role
+metadata:
+  name: mysql-agent{{ if .Values.operator.global }}{{ else}}
+  namespace: {{ .Values.operator.namespace}}{{ end }}
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+
+  - apiGroups:
+    - mysql.oracle.com
+    resources:
+    - mysqlbackups
+    - mysqlbackupschedules
+    - mysqlclusters
+    - mysqlrestores
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind:  {{ if .Values.operator.global }}Cluster{{ end }}RoleBinding
 metadata:
   name: mysql-operator
   namespace: {{ .Values.operator.namespace}}
@@ -38,18 +134,19 @@ subjects:
 - kind: ServiceAccount
   name: mysql-operator
   namespace: {{ .Values.operator.namespace }}
+
 ---
-kind: {{ if .Values.operator.global }}Cluster{{ end }}RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind:  {{ if .Values.operator.global }}Cluster{{ end }}RoleBinding
 metadata:
   name: mysql-agent
-  namespace: {{ if .Values.operator.global }}default{{ else }}{{ .Values.operator.namespace }}{{ end }}
+  namespace: {{ .Values.operator.namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: {{ if .Values.operator.global }}Cluster{{ end }}Role
-  name: mysql-operator
+  kind:  {{ if .Values.operator.global }}Cluster{{ end }}Role
+  name: mysql-agent
 subjects:
 - kind: ServiceAccount
   name: mysql-agent
-  namespace: {{ if .Values.operator.global }}default{{ else }}{{ .Values.operator.namespace }}{{ end }}
+  namespace: {{ .Values.operator.namespace }}
 {{- end }}

--- a/mysql-operator/values.yaml
+++ b/mysql-operator/values.yaml
@@ -1,5 +1,5 @@
 rbac:
-  enabled: false
+  enabled: true
 operator:
   namespace: mysql-operator
   global: true

--- a/pkg/controllers/cluster/config_control.go
+++ b/pkg/controllers/cluster/config_control.go
@@ -16,39 +16,27 @@ package cluster
 
 import (
 	"k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
-	corelisters "k8s.io/client-go/listers/core/v1"
 )
 
 // ConfigMapControlInterface defines the interface that the
-// MySQLClusterController uses to create, update, and delete Configmap. It
-// is implemented as an interface to enable testing.
+// MySQLClusterController uses to create Configmaps. It is implemented as an
+// interface to enable testing.
 type ConfigMapControlInterface interface {
 	CreateConfigMap(c *v1.ConfigMap) error
-	DeleteConfigMap(c *v1.ConfigMap) error
 }
 
 type realConfigMapControl struct {
-	client          kubernetes.Interface
-	configMapLister corelisters.ConfigMapLister
+	client kubernetes.Interface
 }
 
 // NewRealConfigMapControl creates a concrete implementation of the
 // ConfigMapControlInterface.
-func NewRealConfigMapControl(client kubernetes.Interface, ConfigMapLister corelisters.ConfigMapLister) ConfigMapControlInterface {
-	return &realConfigMapControl{client: client, configMapLister: ConfigMapLister}
+func NewRealConfigMapControl(client kubernetes.Interface) ConfigMapControlInterface {
+	return &realConfigMapControl{client: client}
 }
 
 func (rsc *realConfigMapControl) CreateConfigMap(c *v1.ConfigMap) error {
 	_, err := rsc.client.CoreV1().ConfigMaps(c.Namespace).Create(c)
-	return err
-}
-
-func (rsc *realConfigMapControl) DeleteConfigMap(c *v1.ConfigMap) error {
-	err := rsc.client.CoreV1().ConfigMaps(c.Namespace).Delete(c.Name, nil)
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
 	return err
 }

--- a/pkg/controllers/cluster/secret_control.go
+++ b/pkg/controllers/cluster/secret_control.go
@@ -16,7 +16,6 @@ package cluster
 
 import (
 	"k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -24,13 +23,12 @@ import (
 	"github.com/oracle/mysql-operator/pkg/resources/secrets"
 )
 
-// SecretControlInterface defines the interface that the
-// MySQLClusterController uses to create, update, and delete Secrets. It
-// is implemented as an interface to enable testing.
+// SecretControlInterface defines the interface that the MySQLClusterController
+// uses to get and create Secrets. It is implemented as an interface to enable
+// testing.
 type SecretControlInterface interface {
 	GetForCluster(cluster *api.MySQLCluster) (*v1.Secret, error)
 	CreateSecret(s *v1.Secret) error
-	DeleteSecret(s *v1.Secret) error
 }
 
 type realSecretControl struct {
@@ -51,13 +49,5 @@ func (rsc *realSecretControl) GetForCluster(cluster *api.MySQLCluster) (*v1.Secr
 
 func (rsc *realSecretControl) CreateSecret(s *v1.Secret) error {
 	_, err := rsc.client.CoreV1().Secrets(s.Namespace).Create(s)
-	return err
-}
-
-func (rsc *realSecretControl) DeleteSecret(s *v1.Secret) error {
-	err := rsc.client.CoreV1().Secrets(s.Namespace).Delete(s.Name, nil)
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
 	return err
 }

--- a/pkg/controllers/cluster/service_control.go
+++ b/pkg/controllers/cluster/service_control.go
@@ -16,17 +16,14 @@ package cluster
 
 import (
 	"k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 )
 
-// ServiceControlInterface defines the interface that the
-// MySQLClusterController uses to create, update, and delete Services. It
-// is implemented as an interface to enable testing.
+// ServiceControlInterface defines the interface that the MySQLClusterController
+// uses to create Services. It is implemented as an interface to enable testing.
 type ServiceControlInterface interface {
 	CreateService(s *v1.Service) error
-	DeleteService(s *v1.Service) error
 }
 
 type realServiceControl struct {
@@ -42,13 +39,5 @@ func NewRealServiceControl(client kubernetes.Interface, serviceLister corelister
 
 func (rsc *realServiceControl) CreateService(s *v1.Service) error {
 	_, err := rsc.client.CoreV1().Services(s.Namespace).Create(s)
-	return err
-}
-
-func (rsc *realServiceControl) DeleteService(s *v1.Service) error {
-	err := rsc.client.CoreV1().Services(s.Namespace).Delete(s.Name, nil)
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
 	return err
 }

--- a/pkg/controllers/cluster/statefulset_control.go
+++ b/pkg/controllers/cluster/statefulset_control.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 
 	apps "k8s.io/api/apps/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubernetes "k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1beta1"
 
@@ -29,12 +27,11 @@ import (
 )
 
 // StatefulSetControlInterface defines the interface that the
-// MySQLClusterController uses to create, update, and delete StatefulSets. It
+// MySQLClusterController uses to create and update StatefulSets. It
 // is implemented as an interface to enable testing.
 type StatefulSetControlInterface interface {
 	CreateStatefulSet(ss *apps.StatefulSet) error
-	DeleteStatefulSet(ss *apps.StatefulSet) error
-	PatchStatefulSet(old *apps.StatefulSet, new *apps.StatefulSet) error
+	Patch(old *apps.StatefulSet, new *apps.StatefulSet) error
 }
 
 type realStatefulSetControl struct {
@@ -53,17 +50,7 @@ func (rssc *realStatefulSetControl) CreateStatefulSet(ss *apps.StatefulSet) erro
 	return err
 }
 
-func (rssc *realStatefulSetControl) DeleteStatefulSet(ss *apps.StatefulSet) error {
-	policy := metav1.DeletePropagationBackground
-	opts := &metav1.DeleteOptions{PropagationPolicy: &policy}
-	err := rssc.client.AppsV1beta1().StatefulSets(ss.Namespace).Delete(ss.Name, opts)
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-	return err
-}
-
-func (rssc *realStatefulSetControl) PatchStatefulSet(old *apps.StatefulSet, new *apps.StatefulSet) error {
+func (rssc *realStatefulSetControl) Patch(old *apps.StatefulSet, new *apps.StatefulSet) error {
 	_, err := util.PatchStatefulSet(rssc.client, old, new)
 	return err
 }

--- a/pkg/controllers/cluster/statefulset_control_test.go
+++ b/pkg/controllers/cluster/statefulset_control_test.go
@@ -30,7 +30,7 @@ func NewFakeStatefulSetControl(statefulSetControl StatefulSetControlInterface, c
 	return &fakeStatefulSetControl{statefulSetControl, client}
 }
 
-func (rssc *fakeStatefulSetControl) PatchStatefulSet(old *apps.StatefulSet, new *apps.StatefulSet) error {
+func (rssc *fakeStatefulSetControl) Patch(old *apps.StatefulSet, new *apps.StatefulSet) error {
 	_, err := util.UpdateStatefulSet(rssc.client, new)
 	return err
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -147,7 +147,10 @@ e2e-test:
       code: |
         export KUBECONFIG="/tmp/kubeconfig"
         echo -n "${KUBECONFIG_VAR}" | openssl enc -base64 -d -A > "${KUBECONFIG}"
-        ginkgo -nodes=4 -v test/e2e -- \
+        ginkgo \
+          -nodes=5 \
+          -v \
+          test/e2e -- \
           --kubeconfig="${KUBECONFIG}" \
           --operator-version="$(cat dist/version.txt)" \
           --s3-access-key="${S3_ACCESS_KEY}" \


### PR DESCRIPTION
Separates the `mysql-operator` and `mysql-agent` ClusterRoles and scopes the RBAC to the minimal permissions required by each.


### Changelog

```
- Independent ServiceAccounts for the operator and agents.
- Scope RBAC to the minimum required permissions.
- Drop support for Kubernetes 1.7.
```