### PR TITLE
Fix tutorial bugs

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -87,13 +87,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mysql-agent
-  namespace: my-namespace
+  namespace: default
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: mysql-agent
-  namespace: my-namespace
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -101,14 +101,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: mysql-agent
-  namespace: my-namespace
+  namespace: default
 EOF
 ```
 
 Now let's create a new MySQL cluster. Create a cluster.yaml file with the following contents
 
 ```yaml
-apiVersion: mysql.oracle.com/v1
+apiVersion: mysql.oracle.com/v1alpha1
 kind: MySQLCluster
 metadata:
   name: myappdb


### PR DESCRIPTION
This fixes an inconsistency where you add the mysql-agent sa to
"my-namespace" but then proceed to add a database to "default".

Set apiVersion to the correct value of "mysql.oracle.com/v1alpha1"

---

I make this contribution available under the Apache License 2.0. I do
not, and will not, sign nor agree to the Oracle CLA. I do not feel doing 
so is worth the time nor money to have my attorney review it. Based 
on Oracle's past behavior with regard to the Linux community, I do not 
trust an Oracle agreement to have the best interest of the community 
as its intent thus will not sign without legal review.