### PR TITLE
Fix how VERSION var is set in Makefile for build-release workflow on …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 ifdef WERCKER
     # Insert swear words about mysql group replication and hostname length. Arghh..
-    VERSION := ${WERCKER_GIT_COMMIT}
+    VERSION ?= ${WERCKER_GIT_COMMIT}
     TENANT := "oracle"
 else
     NEW_NAMESPACE ?= e2e-${USER}


### PR DESCRIPTION
…Wercker

This allows setting release version string as env var on Wercker before running
the build-release workflow.

Found whilst releasing 0.1.1 off release-0.1 branch