### PR TITLE
Support overriding docker registry for operator and agent in Helm chart

### DIFF
--- a/mysql-operator/templates/03-deployment.yaml
+++ b/mysql-operator/templates/03-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
       - name: mysql-operator-controller
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        image: iad.ocir.io/oracle/mysql-operator:{{ .Values.image.tag }}
+        image: {{ .Values.image.registry }}/mysql-operator:{{ .Values.image.tag }}
         ports:
         - containerPort: 10254
         args:
@@ -32,3 +32,4 @@ spec:
 {{- if not .Values.operator.global }}
           - --namespace={{- .Values.operator.namespace }}
 {{- end }}
+          - --mysql-agent-image={{- .Values.image.registry }}/mysql-agent:{{ .Values.image.tag }}

--- a/mysql-operator/values.yaml
+++ b/mysql-operator/values.yaml
@@ -5,5 +5,6 @@ operator:
   global: true
   register_crd: true
 image:
+  registry: iad.ocir.io/oracle
   tag: 0.1.0
   pullPolicy: Always


### PR DESCRIPTION
This allows a better dev process as we push our dev builds to a different
ocir registry.

```
make push
helm install --name my-release \
--set operator.namespace=default \
--set operator.global=false \
--set rbac.enabled=true \
--set image.registry=iad.ocir.io/<dev-build-tenancy> \
--set image.tag=slord-20180611104750 \
./mysql-operator
```