### PR TITLE
Fix cluster config (alpha1 -> v1alpha1)

### DIFF
--- a/examples/cluster/cluster-with-custom-config.yaml
+++ b/examples/cluster/cluster-with-custom-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: mysql.oracle.com/alpha1
+apiVersion: mysql.oracle.com/v1alpha1
 kind: Cluster
 metadata:
   name: mysql


### PR DESCRIPTION
Hi

Small fix to the api version to make the cluster configuration examples work.

At the moment I'm hesitant to sign the Oracle CLA, I make this commit under the Apache License 2.0, feel free to use it as is, or also just report the changes in your own commit, I don't mind. Please let me know if it's going to be a problem.

Thanks

