### PR TITLE
Properly exclude the local instance from the seeds list

### DIFF
--- a/pkg/controllers/cluster/manager/innodb_cluster.go
+++ b/pkg/controllers/cluster/manager/innodb_cluster.go
@@ -76,7 +76,7 @@ func getReplicationGroupSeeds(seeds string, pod *cluster.Instance) ([]string, er
 		if err != nil {
 			return nil, err
 		}
-		if seedInstance.PodName() == pod.Name() {
+		if seedInstance.Name() == pod.Name() {
 			continue
 		}
 		s = append(s, seed)

--- a/pkg/controllers/cluster/manager/innodb_cluster_test.go
+++ b/pkg/controllers/cluster/manager/innodb_cluster_test.go
@@ -32,11 +32,11 @@ func TestGetReplicationGroupSeeds(t *testing.T) {
 		{
 			seeds:    "server-1-0:1234,server-1-1:1234",
 			pod:      cluster.NewInstance("", "", "server-1", 0, -1, false),
-			expected: []string{"server-1-0:1234", "server-1-1:1234"},
+			expected: []string{"server-1-1:1234"},
 		}, {
 			seeds:    "server-1-1:1234,server-1-0:1234",
 			pod:      cluster.NewInstance("", "", "server-1", 0, -1, false),
-			expected: []string{"server-1-1:1234", "server-1-0:1234"},
+			expected: []string{"server-1-1:1234"},
 		}, {
 			seeds:    "server-1-0:1234,server-1-1:1234",
 			pod:      cluster.NewInstance("", "", "server-2", 0, -1, false),


### PR DESCRIPTION
Hi

Not sure if this is the proper fix, but while testing this I noticed that the local instance is never excluded from the seed list, because we are comparing `Instance.Name()` with `Instance.PodName()`, which never leads to the same results, at least in my experiments.

Since the comment on top of the `getReplicationGroupSeeds` function says `It removes the local instance of mysql from the group`, it seems a reasonable fix to do.

The updated tests also reflect the logic of excluding the local instance from the seed.

At the moment I'm hesitant to sign the Oracle CLA, I make this commit under the Apache License 2.0, feel free to use it as is, or also just report the changes in your own commit, I don't mind. Please let me know if it's going to be a problem.

Thanks