### PR TITLE
Optional aggressive way to automatically recover from loss of quorum

### DIFF
--- a/cmd/mysql-agent/app/mysql_agent.go
+++ b/cmd/mysql-agent/app/mysql_agent.go
@@ -90,7 +90,7 @@ func Run(opts *options.MySQLAgentOpts) error {
 
 	var wg sync.WaitGroup
 
-	manager, err := clustermgr.NewLocalClusterManger(kubeclient, kubeInformerFactory)
+	manager, err := clustermgr.NewLocalClusterManger(kubeclient, kubeInformerFactory, opts.ForceNoQuorumShutdown)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new local MySQL InnoDB cluster manager")
 	}

--- a/cmd/mysql-agent/app/options/options.go
+++ b/cmd/mysql-agent/app/options/options.go
@@ -54,6 +54,9 @@ type MySQLAgentOpts struct {
 	// minResyncPeriod is the resync period in reflectors; will be random
 	// between minResyncPeriod and 2*minResyncPeriod.
 	MinResyncPeriod metav1.Duration
+
+	// Force database shutdown on NO_QUORUM
+	ForceNoQuorumShutdown bool
 }
 
 // NewMySQLAgentOpts instantiates a new default
@@ -66,12 +69,13 @@ func NewMySQLAgentOpts() *MySQLAgentOpts {
 	namespace := os.Getenv("POD_NAMESPACE")
 	clusterName := os.Getenv("MYSQL_CLUSTER_NAME")
 	return &MySQLAgentOpts{
-		HealthcheckPort: DefaultMySQLAgentHeathcheckPort,
-		Address:         "0.0.0.0",
-		Namespace:       namespace,
-		ClusterName:     clusterName,
-		Hostname:        hostname,
-		MinResyncPeriod: metav1.Duration{Duration: 12 * time.Hour},
+		HealthcheckPort:       DefaultMySQLAgentHeathcheckPort,
+		Address:               "0.0.0.0",
+		Namespace:             namespace,
+		ClusterName:           clusterName,
+		Hostname:              hostname,
+		MinResyncPeriod:       metav1.Duration{Duration: 12 * time.Hour},
+		ForceNoQuorumShutdown: false,
 	}
 }
 
@@ -84,6 +88,7 @@ func (s *MySQLAgentOpts) AddFlags(fs *pflag.FlagSet) *pflag.FlagSet {
 	fs.StringVar(&s.ClusterName, "cluster-name", s.ClusterName, "The name of the MySQL cluster the mysql-agent is responsible for.")
 	fs.StringVar(&s.Hostname, "hostname", s.Hostname, "The hostname of the pod the mysql-agent is running in.")
 	fs.DurationVar(&s.MinResyncPeriod.Duration, "min-resync-period", s.MinResyncPeriod.Duration, "The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod.")
+	fs.BoolVar(&s.ForceNoQuorumShutdown, "force-no-quorum-shutdown", s.ForceNoQuorumShutdown, "Force database shutdown of cluster members who see a NO_QUORUM state, in an attempt to automatically recover the cluster.")
 
 	return fs
 }

--- a/pkg/cluster/innodb/innodb.go
+++ b/pkg/cluster/innodb/innodb.go
@@ -31,11 +31,12 @@ type InstanceStatus string
 
 // Instance statuses.
 const (
-	InstanceStatusOnline     InstanceStatus = "ONLINE"
-	InstanceStatusMissing                   = "(MISSING)"
-	InstanceStatusRecovering                = "RECOVERING"
-	InstanceStatusNotFound                  = ""
-	InstanceStatusUnknown                   = "UNKNOWN"
+	InstanceStatusOnline      InstanceStatus = "ONLINE"
+	InstanceStatusMissing                    = "(MISSING)"
+	InstanceStatusRecovering                 = "RECOVERING"
+	InstanceStatusUnreachable                = "UNREACHABLE"
+	InstanceStatusNotFound                   = ""
+	InstanceStatusUnknown                    = "UNKNOWN"
 )
 
 // instanceState denotes the state of a MySQL Instance.
@@ -79,12 +80,24 @@ type InstanceState struct {
 	State  instanceState  `json:"state"`
 }
 
+// ReplicaSetStatus denotes the state of a MySQL replica set.
+type ReplicaSetStatus string
+
+// Replica set statuses
+const (
+	ReplicaSetStatusOk            ReplicaSetStatus = "OK"
+	ReplicaSetStatusOkPartial                      = "OK_PARTIAL"
+	ReplicaSetStatusOkNoTolerance                  = "OK_NO_TOLERANCE"
+	ReplicaSetStatusNoQuorum                       = "NO_QUORUM"
+	ReplicaSetStatusUnknown                        = "UNKNOWN"
+)
+
 // ReplicaSet holds the server instances which belong to an InnoDB
 // cluster.
 type ReplicaSet struct {
 	Name       string               `json:"name"`
 	Primary    string               `json:"primary"`
-	Status     string               `json:"status"`
+	Status     ReplicaSetStatus     `json:"status"`
 	StatusText string               `json:"statusText"`
 	Topology   map[string]*Instance `json:"topology"`
 }

--- a/pkg/controllers/cluster/manager/metrics.go
+++ b/pkg/controllers/cluster/manager/metrics.go
@@ -21,6 +21,7 @@ import (
 var (
 	clusterCreateCount       = metrics.NewAgentEventCounter("cluster_created", "Total number of times an innodb cluster is successfully created")
 	clusterCreateErrorCount  = metrics.NewAgentEventCounter("cluster_create_error", "Total number of times and innodb cluster fails to create")
+	clusterNoQuorumCount     = metrics.NewAgentEventCounter("cluster_no_quorum", "Total number of times the cluster has been seen in a NO_QUORUM state from an instance")
 	instanceAddCount         = metrics.NewAgentEventCounter("instance_added", "Total number of times an instance is successfully added to the innodb cluster")
 	instanceAddErrorCount    = metrics.NewAgentEventCounter("instance_add_error", "Total number of times an instance failed to add to the innodb cluster")
 	instanceRejoinCount      = metrics.NewAgentEventCounter("instance_rejoined", "Total number of times an instance successfully rejoins the innodb cluster")
@@ -32,6 +33,7 @@ var (
 func RegisterMetrics() {
 	metrics.RegisterAgentMetric(clusterCreateCount)
 	metrics.RegisterAgentMetric(clusterCreateErrorCount)
+	metrics.RegisterAgentMetric(clusterNoQuorumCount)
 	metrics.RegisterAgentMetric(instanceAddCount)
 	metrics.RegisterAgentMetric(instanceAddErrorCount)
 	metrics.RegisterAgentMetric(instanceRejoinCount)


### PR DESCRIPTION
Hi

I am having some troubles dealing with failures that involve the majority of the cluster, and I'll try to explain what I see. Please apologize if I'm saying something silly, up until a week ago I didn't even know MySQL had replication capabilities, so this is all new to me.

The configuration I'm using is always 3 members, single primary. Also, in the examples below the primary is `mysql-0` and the slaves are `mysql-1` and `mysql-2`.

**Failure 1 - Expected behavior**

In this scenario, I simulate a **graceful** simultaneous termination of the majority, by terminating `mysql-1` and `mysql-2`. This can be achieved by sending a `SIGTERM` to the mysqld processes (either manually or by using `kubectl delete pod`). Upon receiving such signal, the two mysql slaves correctly inform the remaining cluster that they are leaving, as shown in the logs:

```
2018-06-13T15:47:43.242768Z 0 [Note] [MY-010067] [Server] Giving 4 client threads a chance to die gracefully
2018-06-13T15:47:43.242811Z 0 [Note] [MY-010117] [Server] Shutting down slave threads
2018-06-13T15:47:43.242820Z 0 [Note] [MY-010054] [Server] Event Scheduler: Killing the scheduler thread, thread id 5
2018-06-13T15:47:43.242829Z 0 [Note] [MY-010050] [Server] Event Scheduler: Waiting for the scheduler thread to reply
2018-06-13T15:47:43.242903Z 0 [Note] [MY-010048] [Server] Event Scheduler: Stopped
2018-06-13T15:47:43.824212Z 0 [Note] [MY-011325] [Server] Plugin mysqlx reported: 'Shutdown triggered by mysqld abort flag'
2018-06-13T15:47:43.824659Z 0 [Note] [MY-011321] [Server] Plugin mysqlx reported: 'Scheduler "work" stopped.'
2018-06-13T15:47:43.824724Z 0 [Note] [MY-011329] [Server] Plugin mysqlx reported: 'Stopped handling incoming connections'
2018-06-13T15:47:45.243087Z 0 [Note] [MY-010118] [Server] Forcefully disconnecting 3 remaining clients
2018-06-13T15:47:45.243132Z 0 [Note] [MY-011650] [Repl] Plugin group_replication reported: 'Plugin 'group_replication' is stopping.'
2018-06-13T15:47:45.243160Z 0 [Note] [MY-011647] [Repl] Plugin group_replication reported: 'Going to wait for view modification'
2018-06-13T15:47:45.244405Z 0 [Note] [MY-011735] [Repl] Plugin group_replication reported: '[GCS] Re-using server node 0 host mysql-0.mysql'
2018-06-13T15:47:45.244430Z 0 [Note] [MY-011735] [Repl] Plugin group_replication reported: '[GCS] Re-using server node 1 host mysql-2.mysql'
2018-06-13T15:47:45.244440Z 0 [Note] [MY-011735] [Repl] Plugin group_replication reported: '[GCS] Installed site start={3c5288a 1054 0} boot_key={3c5288a 1043 2} node 4294967295'
...
```

As a result, the cluster readjusts and shifts the quorum requirement, as seen from `mysql-0`:

```
{
    "clusterName": "Cluster",
    "defaultReplicaSet": {
        "name": "default",
        "primary": "mysql-0.mysql:3306",
        "ssl": "REQUIRED",
        "status": "OK_NO_TOLERANCE",
        "statusText": "Cluster is NOT tolerant to any failures. 2 members are not active",
        "topology": {
            "mysql-0.mysql:3306": {
                "address": "mysql-0.mysql:3306",
                "mode": "R/W",
                "readReplicas": {},
                "role": "HA",
                "status": "ONLINE"
            },
            "mysql-1.mysql:3306": {
                "address": "mysql-1.mysql:3306",
                "mode": "R/O",
                "readReplicas": {},
                "role": "HA",
                "status": "(MISSING)"
            },
            "mysql-2.mysql:3306": {
                "address": "mysql-2.mysql:3306",
                "mode": "R/O",
                "readReplicas": {},
                "role": "HA",
                "status": "(MISSING)"
            }
        }
    },
    "groupInformationSourceMember": "mysql://root@mysql-0.mysql:3306"
}
```

As you can see, even if we lost the original majority, the cluster readjusted and it is in fact working as if the entire cluster was now composed of just 1 member, and it's still accepting writes despite not having a majority, with the expected status `OK_NO_TOLERANCE`. It knows it's safe to do so, because it receives explicit termination confirmation from the leaving members, so there are no chances of them going off and forming a majority of their own (e.g network partition).

When the other replicas come back up, rescheduled by Kubernetes, they connect via `mysql-0` and try to rejoin or add themselves as new according to the logic in `handleInstanceMissing`.

So, the operator does its job nicely here.

**Failure 2 - Unexpected behavior**

This scenario is almost exactly like the previous one, except that, instead of gracefully terminating the majority, I simulate a crash or a network partition. In this case, I simply sent the SIGKILL signal to `mysql-1` and `mysql-2`, preventing them from informing the cluster that they are leaving.

What happens now is fundamentally different, the cluster doesn't readjust, quorum is lost, and writes are blocked indefinitely, because `mysql-0` cannot assume that the other two instances didn't form a majority in a different network partition:

```
{
    "clusterName": "Cluster",
    "defaultReplicaSet": {
        "name": "default",
        "primary": "mysql-0.mysql:3306",
        "ssl": "REQUIRED",
        "status": "NO_QUORUM",
        "statusText": "Cluster has no quorum as visible from 'mysql-0.mysql:3306' and cannot process write transactions. 2 members are not active",
        "topology": {
            "mysql-0.mysql:3306": {
                "address": "mysql-0.mysql:3306",
                "mode": "R/W",
                "readReplicas": {},
                "role": "HA",
                "status": "ONLINE"
            },
            "mysql-1.mysql:3306": {
                "address": "mysql-1.mysql:3306",
                "mode": "R/O",
                "readReplicas": {},
                "role": "HA",
                "status": "UNREACHABLE"
            },
            "mysql-2.mysql:3306": {
                "address": "mysql-2.mysql:3306",
                "mode": "R/O",
                "readReplicas": {},
                "role": "HA",
                "status": "UNREACHABLE"
            }
        }
    },
    "groupInformationSourceMember": "mysql://root@mysql-0.mysql:3306"
}
```

From the `mysql-0` log:

```
2018-06-13T18:07:36.966005Z 0 [Warning] [MY-011493] [Repl] Plugin group_replication reported: 'Member with address mysql-1.mysql:3306 has become unreachable.'
2018-06-13T18:07:36.966032Z 0 [Warning] [MY-011493] [Repl] Plugin group_replication reported: 'Member with address mysql-2.mysql:3306 has become unreachable.'
2018-06-13T18:07:36.966039Z 0 [ERROR] [MY-011495] [Repl] Plugin group_replication reported: 'This server is not able to reach a majority of members in the group. This server will now block all updates. The server will remain blocked until contact with the majority is restored. It is possible to use group_replication_force_members to force a new group membership.'
```

Now, according to the reference documentation, one solution would be for a human to go and look at the status of the cluster, then manually select one `ONLINE` replica and re-establish the quorum manually:

```
> dba.getCluster().forceQuorumUsingPartitionOf('root:password@mysql-0.mysql')
Restoring replicaset 'default' from loss of quorum, by using the partition composed of [mysql-0.mysql:3306]

Restoring the InnoDB cluster ...

The InnoDB cluster was successfully restored using the partition from the instance 'root@mysql-0.mysql'.

WARNING: To avoid a split-brain scenario, ensure that all other members of the replicaset are removed or joined back to the group that was restored.
```

The trick here is the "human" part: it would probably be very unwise for the operator to automatically try to issue the `forceQuorumUsingPartitionOf` command on an ONLINE replica, because, in case the other non-online instances are in fact online in a different network partition, we would effectively be forming a split brain, screwing up big time, so manual inspection is crucial.

So, apparently the situation seems unrecoverable and we have no way for the operator to proceed until the other instances come back up. The problem is that, even when `mysql-1` and `mysql-2` come back online and try to join via `mysql-0`, nothing happens, and by nothing I mean:

1) The agent tries to first connect via mysqlsh to the local instance, but it gets `GetCluster(): This function is not available through a session to a standalone instance (metadata exists, but GR is not active)`.
2) The agent then tries to connect to `mysql-0`, and it gets the proper cluster status. However, there's nothing it can do to join/rejoin since there is no quorum (and by the way the `UNREACHABLE` state is currently ignored in the code).

Even trying to manually use mysqlsh to rejoin the instances, we get:

```
> dba.getCluster().addInstance('foo')
Cluster.addInstance: There is no quorum to perform the operation (RuntimeError)
```

At this point I was about to give up, however, if I restart `mysql-0`, it seems to completely forget the `NO_QUORUM` problem, and when it restarts it comes back with a fresh `OK_NO_TOLERANCE` status, thanks to the special code for the first instance in the `rebootFromOutage` function:

```
{                                                                                                                                                                                                                                             
    "clusterName": "Cluster",
    "defaultReplicaSet": {
        "name": "default",
        "primary": "mysql-0.mysql:3306",
        "ssl": "REQUIRED",
        "status": "OK_NO_TOLERANCE",
        "statusText": "Cluster is NOT tolerant to any failures. 2 members are not active",
        "topology": {
            "mysql-0.mysql:3306": {
                "address": "mysql-0.mysql:3306",
                "mode": "R/W",
                "readReplicas": {},
                "role": "HA",
                "status": "ONLINE"
            },
            "mysql-1.mysql:3306": {
                "address": "mysql-1.mysql:3306",
                "mode": "R/O",
                "readReplicas": {},
                "role": "HA",
                "status": "(MISSING)"
            },
            "mysql-2.mysql:3306": {
                "address": "mysql-2.mysql:3306",
                "mode": "R/O",
                "readReplicas": {},
                "role": "HA",
                "status": "(MISSING)"
            }
        }
    },
    "groupInformationSourceMember": "mysql://root@mysql-0.mysql:3306"
}
```

At which point, all the other slaves happily rejoin the cluster. In other words, it's kind of funny that the operator tries to recover from a full cluster outage, but instead ignores a slightly less destructive cluster outage :-)

So, for my use case I decided to implement a new optional flag in the agent, called `force-no-quorum-shutdown`, that will shut down every instance in the cluster that sees the `NO_QUORUM` status, leading to them being restarted by Kubernetes. They will all wait in the "metadata exists, but GR is not present" until the first instance of the statefulset does the same and properly calls `rebootFromOutage`, restoring the cluster like in the previous example, at which point they'll join again.

Of course this is not advisable by default for two reasons:

1) By shutting down instances we lose read availability, and some users might prefer read availability vs some downtime to restore the cluster. In my case, I care about full read/write availability with minimal human operator intervention.

2) There could be some chances of forming a split brain scenario, so this is definitely not a distributed theory-approved solution, and more like a practical hack. In my opinion this is relatively tolerable. Also, any sort of split-brain scenario that could arise from this option could also simply just happen with the current code because, if restarting the first statefulset instance in a NO_QUORUM state somehow triggers the creation of a split-brain, the exact same could happen if such instance were to accidentally crash during the NO_QUORUM state, because it would immediately get rescheduled by Kubernetes, executing the exact same code that I'm trying to explicitly trigger with this patch.

Why I didn't use `forceQuorumUsingPartitionOf`? That could be an option too, but I don't see how it would solve the issue, since clearly after forming a new partition the old members need to be rejoin the proper cluster. Also, I would need explicit synchronization to answer the question "whom of the N ONLINE instances who see the NO_QUORUM state should execute the forceQuorumUsingPartitionOf"? Whereas with this hack, I just shut everybody down and rely on the first statefulset instance to reboot the cluster from outage like we do for the other cases, and hope for the best.

I don't expect this PR to be merged because it can be considered controversial (after all, I believe in a system like MySQL it's completely ok to just say "yes, you're screwed, so plan to never lose quorum unless you want human intervention") and I'm happy to keep it in the fork that I'll use for my project, but I mostly wanted to share this use case to see if there's anything better that could be done from your point of view.

Thanks for reading this long piece.



