### PR TITLE
Fix mysql-agent InvalidImageName

### DIFF
--- a/mysql-operator/templates/03-deployment.yaml
+++ b/mysql-operator/templates/03-deployment.yaml
@@ -32,4 +32,4 @@ spec:
 {{- if not .Values.operator.global }}
           - --namespace={{- .Values.operator.namespace }}
 {{- end }}
-          - --mysql-agent-image={{- .Values.image.registry }}/mysql-agent:{{ .Values.image.tag }}
+          - --mysql-agent-image={{- .Values.image.registry }}/mysql-agent


### PR DESCRIPTION
#128 borked the helm chart without us noticing because e2e tests were failing anyway due to the API changes branch.

```
  Warning  InspectFailed          4m (x186 over 44m)   kubelet, k8s-worker-ad2-0.k8sworkerad2.k8sbmcs.oraclevcn.com  Failed to apply default image tag "iad.ocir.io/oracle/mysql-agent:6f1a359354f18ec33406ba62e8915863da884f01:6f1a359354f18ec33406ba62e8915863da884f01": couldn't parse image reference "iad.ocir.io/oracle/mysql-agent:6f1a359354f18ec33406ba62e8915863da884f01:6f1a359354f18ec33406ba62e8915863da884f01": invalid reference format
```