### PR TITLE
Add missing 'get' verb for mysql-operator to get cluster root passwor…

### DIFF
--- a/mysql-operator/templates/02-rbac.yaml
+++ b/mysql-operator/templates/02-rbac.yaml
@@ -31,7 +31,9 @@ rules:
 
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create"]
+    verbs:
+    - create
+    - get
 
   - apiGroups: [""]
     resources:


### PR DESCRIPTION
…d secret it needs


Not sure why it needs to get them though?

But i was seeing this error without that verb in the rbac file (deploying mysql-operator:0.1.1):

`E0619 09:16:16.418806       1 controller.go:320] error syncing 'default/mysql': could not get secrets from cluster 'default/mysql': secrets "mysql-root-password" is forbidden: User "system:serviceaccount:default:mysql-operator" cannot get secrets in the namespace "default"`