### PR TITLE
Restore native dba.reboot_cluster_from_complete_outage()

### DIFF
--- a/pkg/util/mysqlsh/mysqlsh.go
+++ b/pkg/util/mysqlsh/mysqlsh.go
@@ -193,36 +193,8 @@ func (r *runner) run(ctx context.Context, python string) ([]byte, error) {
 }
 
 func (r *runner) RebootClusterFromCompleteOutage(ctx context.Context) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	// NOTE(apryde): This is implemented in SQL rather than as a call to
-	// dba.reboot_cluster_from_complete_outage() due to https://bugs.mysql.com/90793.
-	sql := strings.Join([]string{
-		"RESET PERSIST group_replication_bootstrap_group;",
-		"SET GLOBAL group_replication_bootstrap_group=ON;",
-		"start group_replication;",
-	}, " ")
-
-	args := []string{"--no-wizard", "--uri", r.uri, "--sql", "-e", sql}
-
-	cmd := r.exec.CommandContext(ctx, "mysqlsh", args...)
-
-	cmd.SetStdout(stdout)
-	cmd.SetStderr(stderr)
-
-	glog.V(6).Infof("Running command: mysqlsh %v", args)
-	err := cmd.Run()
-	glog.V(6).Infof("    stdout: %s\n    stderr: %s\n    err: %s", stdout, stderr, err)
-	if err != nil {
-		underlying := NewErrorFromStderr(stderr.String())
-		if underlying != nil {
-			return errors.WithStack(underlying)
-		}
-	}
+	python := fmt.Sprintf("dba.reboot_cluster_from_complete_outage('%s')", innodb.DefaultClusterName)
+	_, err := r.run(ctx, python)
 	return err
 }
 


### PR DESCRIPTION
Hi,

Any reason why we are keeping this around? SSL seems to have been enabled by default for a while now (https://github.com/oracle/mysql-operator/commit/d42c4135459766ad3412e2c34419fa4d96b8e9b9), so it could be useful to restore the native command?

More specifically, the reasoning behind this is:

1) As mentioned in a previous comment, the manual command is not compatible with 5.7 due to the `PERSIST` token (not a super important reason).

2) I'm trying to troubleshoot what seems like a very rare problem and, after certain failures that involve the entire cluster, it just doesn't come up again and the attempt to reboot the cluster by the operator fails. I'm still working on this, but I thought it'd be useful to realign the commands to the official reference to exclude any sort of side effect caused by using a custom command.

3) It's unarguably cleaner.

Thanks and sorry if I missed something

PS: CLA is signed and sent the email almost a week ago, no reply yet.