### PR TITLE
28 length issue

### DIFF
--- a/docs/user/clusters.md
+++ b/docs/user/clusters.md
@@ -43,7 +43,7 @@ Create your cluster and reference it
 apiVersion: mysql.oracle.com/v1alpha1
 kind: Cluster
 metadata:
-  name: example-mysql-cluster-custom-secret
+  name: mysql-cluster-custom-secret
 spec:
   members: 1
   rootPasswordSecret:
@@ -75,7 +75,7 @@ spec:
 apiVersion: mysql.oracle.com/v1alpha1
 kind: Cluster
 metadata:
-  name: example-mysql-cluster-with-volume
+  name: mysql-cluster-with-volume
 spec:
   members: 1
   volumeClaimTemplate:
@@ -132,7 +132,7 @@ spec:
 apiVersion: mysql.oracle.com/v1alpha1
 kind: Cluster
 metadata:
-  name: example-mysql-cluster-with-volume
+  name: mysql-cluster-with-volume
 spec:
   members: 1
   rootPasswordSecret:


### PR DESCRIPTION
Issuing commands "as is" I hitted this problem:

```
E0716 08:16:40.581483       1 controller.go:289] error syncing 'yaxxxay/example-mysql-cluster-with-volume': validating Cluster: metadata.name: Invalid value: "example-mysql-cluster-with-volume": longer than maxi
mum supported length 28 (see: https://bugs.mysql.com/bug.php?id=90601)       
```

**s/example-//** fixed.

Thanks