### PR TITLE
CIDR fixes and kops support

### DIFF
--- a/pkg/cluster/instance.go
+++ b/pkg/cluster/instance.go
@@ -135,6 +135,7 @@ func (i *Instance) WhitelistCIDR() (string, error) {
 		"10.0.0.0/8",
 		"172.16.0.0/12",
 		"192.168.0.0/16",
+		"100.64.0.0/10", // IPv4 shared address space (RFC 6598), improperly used by kops
 	} {
 		_, block, _ := net.ParseCIDR(addrRange)
 		privateRanges = append(privateRanges, block)

--- a/pkg/cluster/instance.go
+++ b/pkg/cluster/instance.go
@@ -129,16 +129,24 @@ func (i *Instance) PodName() string {
 
 // WhitelistCIDR returns the CIDR range to whitelist for GR based on the Pod's IP.
 func (i *Instance) WhitelistCIDR() (string, error) {
-	switch i.IP.To4()[0] {
-	case 10:
-		return "10.0.0.0/8", nil
-	case 172:
-		return "172.16.0.0/12", nil
-	case 192:
-		return "192.168.0.0/16", nil
-	default:
-		return "", errors.Errorf("pod IP %q is not a private IPv4 address", i.IP.String())
+	var privateRanges []*net.IPNet
+
+	for _, addrRange := range []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+	} {
+		_, block, _ := net.ParseCIDR(addrRange)
+		privateRanges = append(privateRanges, block)
 	}
+
+	for _, block := range privateRanges {
+		if block.Contains(i.IP) {
+			return block.String(), nil
+		}
+	}
+
+	return "", errors.Errorf("pod IP %q is not a private IPv4 address", i.IP.String())
 }
 
 // statefulPodRegex is a regular expression that extracts the parent StatefulSet

--- a/pkg/cluster/instance_test.go
+++ b/pkg/cluster/instance_test.go
@@ -15,6 +15,7 @@
 package cluster
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,5 +74,29 @@ func TestGetPodName(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.name, name)
 		})
+	}
+}
+
+func TestWhitelistCIDR(t *testing.T) {
+	testCases := []struct {
+		ip       string
+		expected string
+	}{
+		{ip: "192.168.0.1", expected: "192.168.0.0/16"},
+		{ip: "192.167.0.1", expected: ""},
+		{ip: "10.1.1.1", expected: "10.0.0.0/8"},
+		{ip: "172.15.0.1", expected: ""},
+		{ip: "172.16.0.1", expected: "172.16.0.0/12"},
+		{ip: "172.17.0.1", expected: "172.16.0.0/12"},
+		{ip: "1.2.3.4", expected: ""},
+	}
+
+	for _, tt := range testCases {
+		i := Instance{IP: net.ParseIP(tt.ip)}
+
+		cidr, _ := i.WhitelistCIDR()
+		if cidr != tt.expected {
+			t.Errorf("ip: %v, cidr: %v, expected: %v", tt.ip, cidr, tt.expected)
+		}
 	}
 }

--- a/pkg/cluster/instance_test.go
+++ b/pkg/cluster/instance_test.go
@@ -88,6 +88,8 @@ func TestWhitelistCIDR(t *testing.T) {
 		{ip: "172.15.0.1", expected: ""},
 		{ip: "172.16.0.1", expected: "172.16.0.0/12"},
 		{ip: "172.17.0.1", expected: "172.16.0.0/12"},
+		{ip: "100.64.0.1", expected: "100.64.0.0/10"},
+		{ip: "100.63.0.1", expected: ""},
 		{ip: "1.2.3.4", expected: ""},
 	}
 


### PR DESCRIPTION
This PR introduces two changes, split in separate commits:

1) Better validation of IP addresses to CIDR, since the original algorithm was a little bit weak, and it also adds some tests.

2) Includes the `100.64.0.0/10` address range as valid range.

The reason for 2) is that kops by default seems to be using that range to minimize the likelihood of collisions in the wild[1] . This is in my opinion improper and against the guidelines of the RFC (e.g. [2], [3]), but considering the popularity of kops it's a scenario we have to support, so we either introduce a new configuration parameter inside the CRD that the user can use to manually specify the whitelist range (and this would then be passed to the mysql-agent as argument when the statefulset is first created), or we just hardcode the address range, like I did. The latter has the advantage that it will work out of the box, which is a usability advantage with respect to the other solution in my opinion.

Thanks

[1] https://github.com/kubernetes/kops/issues/2075
[2] https://blog.ipspace.net/2013/08/can-i-use-shared-rfc-6598-ipv4-address.html
[3] https://networkengineering.stackexchange.com/questions/35958/ipv4-segment-100-64-0-0-10