### PR TITLE
Export logs as wercker artifacts and delete e2e namespace on test failure

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -155,7 +155,6 @@ e2e-test:
           --operator-version="$(cat dist/version.txt)" \
           --s3-access-key="${S3_ACCESS_KEY}" \
           --s3-secret-key="${S3_SECRET_KEY}" \
-          --delete-namespace-on-failure=false
 
 release:
   box:


### PR DESCRIPTION
Closes #177 

MySQL Agent, Server and Operator logs will be exported as wercker artifacts on a per pod basis. If tests are run locally they are printed to stdout. E2E test namespace deletion follows regardless of whether the test passes or fails.