### PR TITLE
Set MySQL 8.0.12 as default version

### DIFF
--- a/docker/mysql-agent/Dockerfile
+++ b/docker/mysql-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql/mysql-server:8.0.11
+FROM mysql/mysql-server:8.0.12
 
 COPY bin/linux_amd64/mysql-agent /
 

--- a/pkg/apis/mysql/v1alpha1/helpers.go
+++ b/pkg/apis/mysql/v1alpha1/helpers.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// The default MySQL version to use if not specified explicitly by user
-	defaultVersion      = "8.0.11"
+	defaultVersion      = "8.0.12"
 	defaultMembers      = 3
 	defaultBaseServerID = 1000
 	// maxBaseServerID is the maximum safe value for BaseServerID calculated


### PR DESCRIPTION
This change sets the default MySQL server version to 8.0.12 while leaving the min required version as is (8.0.11). 

For a list of changes in 8.0.12 see [here](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-12.html)