### PR TITLE
Add support for defining securityContext in cluster spec

### DIFF
--- a/pkg/apis/mysql/v1alpha1/types.go
+++ b/pkg/apis/mysql/v1alpha1/types.go
@@ -64,6 +64,8 @@ type ClusterSpec struct {
 	// and server key for group replication SSL.
 	// +optional
 	SSLSecret *corev1.LocalObjectReference `json:"sslSecret,omitempty"`
+	// SecurityContext holds pod-level security attributes and common container settings.
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 }
 
 // ClusterConditionType represents a valid condition of a Cluster.

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -391,5 +391,8 @@ func NewForCluster(cluster *v1alpha1.Cluster, images operatoropts.Images, servic
 	if cluster.Spec.BackupVolumeClaimTemplate != nil {
 		ss.Spec.VolumeClaimTemplates = append(ss.Spec.VolumeClaimTemplates, *cluster.Spec.BackupVolumeClaimTemplate)
 	}
+	if cluster.Spec.SecurityContext != nil {
+		ss.Spec.Template.Spec.SecurityContext = cluster.Spec.SecurityContext
+	}
 	return ss
 }

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -165,3 +165,24 @@ func TestClusterCustomSSLSetup(t *testing.T) {
 
 	assert.True(t, hasExpectedVolumeMount, "Cluster is missing expected volume mount for custom SSL certs")
 }
+
+func TestClusterCustomSecurityContext(t *testing.T) {
+	userID := int64(27)
+	cluster := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser: &userID,
+				FSGroup:   &userID,
+			},
+		},
+	}
+
+	statefulSet := NewForCluster(cluster, mockOperatorConfig().Images, "mycluster")
+
+	if statefulSet.Spec.Template.Spec.SecurityContext != nil {
+		assert.EqualValues(t, userID, *statefulSet.Spec.Template.Spec.SecurityContext.RunAsUser, "SecurityContext Spec runAsUser does not have expected value")
+		assert.Equal(t, userID, *statefulSet.Spec.Template.Spec.SecurityContext.FSGroup, "SecurityContext Spec fsGroup does not have expected value")
+	} else {
+		t.Errorf("StatefulSet Spec is missing SecurityContext definition")
+	}
+}


### PR DESCRIPTION
Support adding a securityContext to the Cluster Spec, for example:
```yml
apiVersion: mysql.oracle.com/v1alpha1
kind: Cluster
metadata:
  name: test-mysql-db
spec:
  multiMaster: true
  members: 3
  securityContext:
    runAsNonRoot: true
    runAsUser: 27
    fsGroup: 27
  ...
```