### PR TITLE
Add support for defining Tolerations in the ClusterSpec

### DIFF
--- a/pkg/apis/mysql/v1alpha1/types.go
+++ b/pkg/apis/mysql/v1alpha1/types.go
@@ -66,6 +66,9 @@ type ClusterSpec struct {
 	SSLSecret *corev1.LocalObjectReference `json:"sslSecret,omitempty"`
 	// SecurityContext holds pod-level security attributes and common container settings.
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	// Tolerations allows specifying a list of tolerations for controlling which
+	// set of nodes a pod can be scheduled on
+	Tolerations *[]corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // ClusterConditionType represents a valid condition of a Cluster.

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -394,5 +394,8 @@ func NewForCluster(cluster *v1alpha1.Cluster, images operatoropts.Images, servic
 	if cluster.Spec.SecurityContext != nil {
 		ss.Spec.Template.Spec.SecurityContext = cluster.Spec.SecurityContext
 	}
+	if cluster.Spec.Tolerations != nil {
+		ss.Spec.Template.Spec.Tolerations = *cluster.Spec.Tolerations
+	}
 	return ss
 }


### PR DESCRIPTION
Fixes: #214 

Support adding tolerations to the Cluster Spec, for example:
```yml
apiVersion: mysql.oracle.com/v1alpha1
kind: Cluster
metadata:
  name: test-mysql-db
spec:
  multiMaster: true
  members: 3
  tolerations:
  - key: "key"
    operator: "Equal"
    value: "value"
    effect: "NoSchedule"
  ...
```