### PR TITLE
Allow defining Resource Requirements per container in the ClusterSpec

### DIFF
--- a/pkg/apis/mysql/v1alpha1/types.go
+++ b/pkg/apis/mysql/v1alpha1/types.go
@@ -64,11 +64,13 @@ type ClusterSpec struct {
 	// and server key for group replication SSL.
 	// +optional
 	SSLSecret *corev1.LocalObjectReference `json:"sslSecret,omitempty"`
-	// SecurityContext holds pod-level security attributes and common container settings.
+	// SecurityContext holds Pod-level security attributes and common Container settings.
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 	// Tolerations allows specifying a list of tolerations for controlling which
-	// set of nodes a pod can be scheduled on
+	// set of Nodes a Pod can be scheduled on
 	Tolerations *[]corev1.Toleration `json:"tolerations,omitempty"`
+	// Resources holds ResourceRequirements for the MySQL Agent & Server Containers
+	Resources *Resources `json:"resources,omitempty"`
 }
 
 // ClusterConditionType represents a valid condition of a Cluster.
@@ -123,6 +125,12 @@ type ClusterList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []Cluster `json:"items"`
+}
+
+// Resources holds ResourceRequirements for the MySQL Agent & Server Containers
+type Resources struct {
+	Agent  *corev1.ResourceRequirements `json:"agent,omitempty"`
+	Server *corev1.ResourceRequirements `json:"server,omitempty"`
 }
 
 // Database represents a database to backup.

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/oracle/mysql-operator/pkg/apis/mysql/v1alpha1"
@@ -220,4 +221,69 @@ func TestClusterWithTolerations(t *testing.T) {
 			assert.Equal(t, corev1.TaintEffectNoExecute, statefulSet.Spec.Template.Spec.Tolerations[1].Effect, "ClusterSpec.Tolerations[1].Effect does not have expected value")
 		}
 	}
+}
+
+func TestClusterWithResourceRequirements(t *testing.T) {
+	mysqlServerResourceRequirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+
+	mysqlAgentResourceRequirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+	}
+
+	cluster := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			Resources: &v1alpha1.Resources{
+				Server: &mysqlServerResourceRequirements,
+				Agent:  &mysqlAgentResourceRequirements,
+			},
+		},
+	}
+
+	statefulSet := NewForCluster(cluster, mockOperatorConfig().Images, "mycluster")
+
+	assert.Equal(t, mysqlServerResourceRequirements, statefulSet.Spec.Template.Spec.Containers[0].Resources, "MySQL-Server container resource requirements do not match expected.")
+	assert.Equal(t, mysqlAgentResourceRequirements, statefulSet.Spec.Template.Spec.Containers[1].Resources, "MySQL-Agent container resource requirements do not match expected.")
+}
+
+func TestClusterWithOnlyMysqlServerResourceRequirements(t *testing.T) {
+	mysqlServerResourceRequirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+
+	cluster := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			Resources: &v1alpha1.Resources{
+				Server: &mysqlServerResourceRequirements,
+			},
+		},
+	}
+
+	statefulSet := NewForCluster(cluster, mockOperatorConfig().Images, "mycluster")
+
+	assert.Equal(t, mysqlServerResourceRequirements, statefulSet.Spec.Template.Spec.Containers[0].Resources, "MySQL-Server container resource requirements do not match expected.")
+	assert.Nil(t, statefulSet.Spec.Template.Spec.Containers[1].Resources.Limits, "MySQL-Agent container has resource limits set which were not initially defined in the spec")
+	assert.Nil(t, statefulSet.Spec.Template.Spec.Containers[1].Resources.Requests, "MySQL-Agent container has resource requests set which were not initially defined in the spec")
 }


### PR DESCRIPTION
If [default resource limits](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace) are defined too low for a namespace, the mysql-server container may fail to bootstrap / run successfully and hit `OOMKilled` errors.

This PR extends the MySQL ClusterSpec to allow defining custom resource requirements per container (server and agent), which are passed onto the StatefulSet definition.