### PR TITLE
Keep mysql readonly after exit group unintentionally

### DIFF
--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -34,7 +34,7 @@ import (
 	"github.com/oracle/mysql-operator/pkg/resources/secrets"
 	"github.com/oracle/mysql-operator/pkg/version"
 
-	goverion "github.com/hashicorp/go-version"
+	"github.com/coreos/go-semver/semver"
 )
 
 const (
@@ -159,22 +159,24 @@ func getReplicationGroupSeeds(name string, members int) string {
 	return strings.Join(seeds, ",")
 }
 
-func checkSupportGroupExitStateArgs(deployingVersion string) bool {
-	ver, err := goverion.NewVersion(deployingVersion)
-	if err != nil {
-		return false
+func checkSupportGroupExitStateArgs(deployingVersion string) (supportedVer bool) {
+	defer func() {
+		if r := recover(); r != nil {
+
+		}
+	}()
+
+	supportedVer = false
+
+	ver := semver.New(deployingVersion)
+	minVer := semver.New(minMysqlVersionWithGroupExitStateArgs)
+
+	if ver.LessThan(*minVer) {
+		return
 	}
 
-	minVer, err := goverion.NewVersion(minMysqlVersionWithGroupExitStateArgs)
-	if err != nil {
-		return false
-	}
-
-	if ver.GreaterThan(minVer) || ver.Equal(minVer) {
-		return true
-	}
-
-	return false
+	supportedVer = true
+	return
 }
 
 // Builds the MySQL operator container for a cluster.

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -209,7 +209,7 @@ func mysqlServerContainer(cluster *v1alpha1.Cluster, mysqlServerImage string, ro
 	}
 
 	if checkSupportGroupExitStateArgs(cluster.Spec.Version) {
-		args = append(args, "--group-replication-exit-state-action=READ_ONLY")
+		args = append(args, "--loose-group-replication-exit-state-action=READ_ONLY")
 	}
 
 	entryPointArgs := strings.Join(args, " ")

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -172,6 +172,7 @@ func mysqlServerContainer(cluster *v1alpha1.Cluster, mysqlServerImage string, ro
 		"--master-info-repository=TABLE",
 		"--relay-log-info-repository=TABLE",
 		"--transaction-write-set-extraction=XXHASH64",
+		"--group-replication-exit-state-action=READ_ONLY",
 		fmt.Sprintf("--relay-log=%s-${index}-relay-bin", cluster.Name),
 		fmt.Sprintf("--report-host=\"%[1]s-${index}.%[1]s\"", cluster.Name),
 		"--log-error-verbosity=3",

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -333,7 +333,7 @@ func TestClusterSetGroupExitStateArgs(t *testing.T) {
 
 	cmd := statefulSet.Spec.Template.Spec.Containers[0].Command[2]
 
-	assert.Contains(t, cmd, "--group-replication-exit-state-action=READ_ONLY")
+	assert.Contains(t, cmd, "--loose-group-replication-exit-state-action=READ_ONLY")
 
 	cluster2 := &v1alpha1.Cluster{}
 	cluster2.EnsureDefaults()
@@ -343,7 +343,7 @@ func TestClusterSetGroupExitStateArgs(t *testing.T) {
 
 	cmd2 := statefulSet2.Spec.Template.Spec.Containers[0].Command[2]
 
-	assert.Contains(t, cmd2, "--group-replication-exit-state-action=READ_ONLY")
+	assert.Contains(t, cmd2, "--loose-group-replication-exit-state-action=READ_ONLY")
 }
 
 func TestClusterNotSetGroupExitStateArgs(t *testing.T) {
@@ -355,5 +355,5 @@ func TestClusterNotSetGroupExitStateArgs(t *testing.T) {
 
 	cmd := statefulSet.Spec.Template.Spec.Containers[0].Command[2]
 
-	assert.NotContains(t, cmd, "--group-replication-exit-state-action=READ_ONLY")
+	assert.NotContains(t, cmd, "--loose-group-replication-exit-state-action=READ_ONLY")
 }

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -323,3 +323,37 @@ func TestClusterDefaultOverride(t *testing.T) {
 
 	assert.Equal(t, "OverrideDefaultImage:"+v1alpha1.DefaultVersion, si)
 }
+
+func TestClusterSetGroupExitStateArgs(t *testing.T) {
+	cluster := &v1alpha1.Cluster{}
+	cluster.EnsureDefaults()
+	cluster.Spec.Version = "8.0.12"
+
+	statefulSet := NewForCluster(cluster, mockOperatorConfig().Images, "mycluster")
+
+	cmd := statefulSet.Spec.Template.Spec.Containers[0].Command[2]
+
+	assert.Contains(t, cmd, "--group-replication-exit-state-action=READ_ONLY")
+
+	cluster2 := &v1alpha1.Cluster{}
+	cluster2.EnsureDefaults()
+	cluster2.Spec.Version = "8.0.13"
+
+	statefulSet2 := NewForCluster(cluster2, mockOperatorConfig().Images, "mycluster")
+
+	cmd2 := statefulSet2.Spec.Template.Spec.Containers[0].Command[2]
+
+	assert.Contains(t, cmd2, "--group-replication-exit-state-action=READ_ONLY")
+}
+
+func TestClusterNotSetGroupExitStateArgs(t *testing.T) {
+	cluster := &v1alpha1.Cluster{}
+	cluster.EnsureDefaults()
+	cluster.Spec.Version = "8.0.11"
+
+	statefulSet := NewForCluster(cluster, mockOperatorConfig().Images, "mycluster")
+
+	cmd := statefulSet.Spec.Template.Spec.Containers[0].Command[2]
+
+	assert.NotContains(t, cmd, "--group-replication-exit-state-action=READ_ONLY")
+}


### PR DESCRIPTION
Since MySQL version >= 8.0.12, <= 8.0.15 changed `group-replication-exit-state-action` default behavior to `ABORT_SERVER`. Which will shutdown the server after exit group unintentionally. It should better change server to `READ_ONLY` instead of exit.

Future version MySQL also change this behavior back to `READ_ONLY` 
https://dev.mysql.com/doc/refman/8.0/en/group-replication-options.html#sysvar_group_replication_exit_state_action

Signed-off-by: Alan Tang <alantang888@gmail.com>