### PR TITLE
Modify the kind of mysql-agent role in contrib/manifests/rbac.yaml

### DIFF
--- a/contrib/manifests/rbac.yaml
+++ b/contrib/manifests/rbac.yaml
@@ -74,7 +74,7 @@ rules:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: Role
 metadata:
   name: mysql-agent
 rules:
@@ -119,7 +119,7 @@ metadata:
   name: mysql-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind:  Role
+  kind: Role
   name: mysql-operator
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
Currently, mysql-agent role (`kind: ClusterRole`) is defined in rbac.yaml, but mysql-agent RoleBinding references `kind: Role`.
This PR modifies the kind of mysql-agent role to match the reference of the RoleBinding.

I have signed and sent OCA document to the email.