### PR TITLE
Metrics ports must be exposed so prometheus operator can match endpoints

### DIFF
--- a/mysql-operator/Chart.yaml
+++ b/mysql-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql-operator
-version: 0.2.1
+version: 0.3.0
 description: A Helm chart for deploying the Oracle MySQL Operator
 maintainers:
   - name: Owain Lewis

--- a/mysql-operator/templates/03-deployment.yaml
+++ b/mysql-operator/templates/03-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         image: {{ .Values.image.registry }}/mysql-operator:{{ .Values.image.tag }}
         ports:
         - containerPort: 10254
+        - containerPort: 8080
         args:
           - --v=4
 {{- if not .Values.operator.global }}

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -268,8 +268,8 @@ func mysqlAgentContainer(cluster *v1alpha1.Cluster, mysqlAgentImage string, root
 	}
 
 	return v1.Container{
-		Name:         MySQLAgentName,
-		Image:        fmt.Sprintf("%s:%s", mysqlAgentImage, agentVersion),
+		Name:  MySQLAgentName,
+		Image: fmt.Sprintf("%s:%s", mysqlAgentImage, agentVersion),
 		Ports: []v1.ContainerPort{
 			{
 				ContainerPort: 8080,

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -270,6 +270,11 @@ func mysqlAgentContainer(cluster *v1alpha1.Cluster, mysqlAgentImage string, root
 	return v1.Container{
 		Name:         MySQLAgentName,
 		Image:        fmt.Sprintf("%s:%s", mysqlAgentImage, agentVersion),
+		Ports: []v1.ContainerPort{
+			{
+				ContainerPort: 8080,
+			},
+		},
 		Args:         []string{"--v=4"},
 		VolumeMounts: volumeMounts(cluster),
 		Env: []v1.EnvVar{


### PR DESCRIPTION
Prometheus operator creates scrape job with relabel_config which check if pod has exposed port.

For example, prometheus operator service monitor spec:
```
  endpoints:
  - targetPort: 8080
    scheme: http
  jobLabel: mysql-cluster
  selector:
    matchLabels:
      v1alpha1.mysql.oracle.com/cluster: mysql-cluster
  namespaceSelector:
    matchNames:
      - infra
```

creates scrape job with kubernetes_sd_configs:

```
  - role: endpoints
    namespaces:
      names:
      - infra
  relabel_configs:
  - source_labels: [__meta_kubernetes_service_label_v1alpha1_mysql_oracle_com_cluster]
    separator: ;
    regex: mysql-cluster
    replacement: $1
    action: keep
  - source_labels: [__meta_kubernetes_pod_container_port_number]
    separator: ;
    regex: "8080"
    replacement: $1
    action: keep
```


Because container ports cannot be updated statefulsets must be patched before upgrading mysql operator:
```
kubectl patch statefulsets.apps mysql-cluster --type=json -p='[{"op": "add", "path": "/spec/template/spec/containers/1/ports", "value": [{"containerPort":8080}] }]' 
```