### PR TITLE
Add PodAnnotations to Cluster

### DIFF
--- a/pkg/apis/mysql/v1alpha1/types.go
+++ b/pkg/apis/mysql/v1alpha1/types.go
@@ -76,6 +76,8 @@ type ClusterSpec struct {
 	Tolerations *[]corev1.Toleration `json:"tolerations,omitempty"`
 	// Resources holds ResourceRequirements for the MySQL Agent & Server Containers
 	Resources *Resources `json:"resources,omitempty"`
+	// PodAnnotations allows adding additional annotations to the pods
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // ClusterConditionType represents a valid condition of a Cluster.

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -383,6 +383,17 @@ func NewForCluster(cluster *v1alpha1.Cluster, images operatoropts.Images, servic
 		podLabels[constants.LabelClusterRole] = constants.ClusterRolePrimary
 	}
 
+	podAnnotations := map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   "8080",
+	}
+
+	if cluster.Spec.PodAnnotations != nil {
+		for k, v := range cluster.Spec.PodAnnotations {
+			podAnnotations[k] = v
+		}
+	}
+
 	ss := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cluster.Namespace,
@@ -403,11 +414,8 @@ func NewForCluster(cluster *v1alpha1.Cluster, images operatoropts.Images, servic
 			Replicas: &cluster.Spec.Members,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: podLabels,
-					Annotations: map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "8080",
-					},
+					Labels:      podLabels,
+					Annotations: podAnnotations,
 				},
 				Spec: v1.PodSpec{
 					// FIXME: LIMITED TO DEFAULT NAMESPACE. Need to dynamically

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -357,3 +357,21 @@ func TestClusterNotSetGroupExitStateArgs(t *testing.T) {
 
 	assert.NotContains(t, cmd, "--loose-group-replication-exit-state-action=READ_ONLY")
 }
+
+func TestClusterWithPodAnnotations(t *testing.T) {
+	cluster := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			PodAnnotations: map[string]string{
+				"sidecar.istio.io/rewriteAppHTTPProbers": "true",
+			},
+		},
+	}
+	cluster.EnsureDefaults()
+
+	statefulSet := NewForCluster(cluster, mockOperatorConfig().Images, "mycluster")
+
+	// check original annotations exist
+	assert.Equal(t, "true", statefulSet.Spec.Template.Annotations["prometheus.io/scrape"])
+	// check additional annotations exist
+	assert.Equal(t, "true", statefulSet.Spec.Template.Annotations["sidecar.istio.io/rewriteAppHTTPProbers"])
+}


### PR DESCRIPTION
Similar `podLabels` mentioned in #86.  I need to add additional annotations to the pods to try to make mysql pods work in istio service mesh.