### PR TITLE
Migrate deprecated API

### DIFF
--- a/mysql-operator/templates/03-deployment.yaml
+++ b/mysql-operator/templates/03-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql-operator


### PR DESCRIPTION
Deployment in the extensions/v1beta1, apps/v1beta1, and apps/v1beta2 API versions is no longer served
Migrate to use the apps/v1 API version, available since v1.9. Existing persisted data can be retrieved/updated via the new version.

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/